### PR TITLE
Update blacklisted objects

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -26,23 +26,39 @@ BLACKLISTED_FIELDS = set(['attributes'])
 
 # The following objects are not supported by the bulk API.
 UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS = set(['ActivityHistory',
-                                      'AssetTokenEvent',
-                                      'EmailStatus',
-                                      'UserRecordAccess'])
+                                               'AssetTokenEvent',
+                                               'EmailStatus',
+                                               'UserRecordAccess',
+                                               'Name',
+                                               'AggregateResult',
+                                               'OpenActivity',
+                                               'ProcessInstanceHistory',
+                                               'SolutionStatus',
+                                               'OwnedContentDocument',
+                                               'FolderedContentDocument',
+                                               'ContractStatus',
+                                               'ContentFolderItem',
+                                               'CombinedAttachment'])
 
 # The following objects have certain WHERE clause restrictions so we exclude them.
 QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(['ContentDocumentLink',
-                                            'CollaborationGroupRecord',
-                                            'Vote',
-                                            'IdeaComment',
-                                            'FieldDefinition',
-                                            'PlatformAction'])
+                                           'CollaborationGroupRecord',
+                                           'Vote',
+                                           'IdeaComment',
+                                           'FieldDefinition',
+                                           'PlatformAction',
+                                           'UserEntityAccess',
+                                           'RelationshipInfo',
+                                           'ContentFolderMember',
+                                           'SearchLayout',
+                                           'EntityParticle'])
 
-# The following objects are not supported by the queryAll method so we cannot retrive
-# deleted objects.
-QUERY_ALL_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['ListViewChartInstances'])
+# The following objects are not supported by the query method being used.
+QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['ListViewChartInstances',
+                                                 'FeedLike',
+                                                 'OutgoingEmailRelation'])
 
-BLACKLISTED_SALESFORCE_OBJECTS = UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS.union(QUERY_RESTRICTED_SALESFORCE_OBJECTS).union(QUERY_ALL_INCOMPATIBLE_SALESFORCE_OBJECTS)
+BLACKLISTED_SALESFORCE_OBJECTS = UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS.union(QUERY_RESTRICTED_SALESFORCE_OBJECTS).union(QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS)
 
 def get_replication_key(sobject_name, fields):
     fields_list = [f['name'] for f in fields]

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -38,7 +38,21 @@ UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS = set(['ActivityHistory',
                                                'FolderedContentDocument',
                                                'ContractStatus',
                                                'ContentFolderItem',
-                                               'CombinedAttachment'])
+                                               'CombinedAttachment',
+                                               'RecentlyViewed',
+                                               'DeclinedEventRelation',
+                                               'ContentBody',
+                                               'AcceptedEventRelation',
+                                               'LookedUpFromActivity',
+                                               'TaskStatus',
+                                               'PartnerRole',
+                                               'NoteAndAttachment',
+                                               'TaskPriority',
+                                               'AttachedContentDocument',
+                                               'CaseStatus',
+                                               'FeedTrackedChange',
+                                               'EntityDefinition', # Blacklisted for RecordTypesSupported field only. This could be removed in discovery.
+                                               'UndecidedEventRelation'])
 
 # The following objects have certain WHERE clause restrictions so we exclude them.
 QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(['ContentDocumentLink',
@@ -51,12 +65,20 @@ QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(['ContentDocumentLink',
                                            'RelationshipInfo',
                                            'ContentFolderMember',
                                            'SearchLayout',
-                                           'EntityParticle'])
+                                           'EntityParticle',
+                                           'OwnerChangeOptionInfo',
+                                           'DataStatistics',
+                                           'UserFieldAccess',
+                                           'PicklistValueInfo',
+                                           'RelationshipDomain',
+                                           'FlexQueueItem'])
 
 # The following objects are not supported by the query method being used.
-QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['ListViewChartInstances',
-                                                 'FeedLike',
-                                                 'OutgoingEmailRelation'])
+QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['ListViewChartInstance',
+                                             'FeedLike',
+                                             'OutgoingEmail',
+                                             'OutgoingEmailRelation',
+                                             'FeedSignal'])
 
 BLACKLISTED_SALESFORCE_OBJECTS = UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS.union(QUERY_RESTRICTED_SALESFORCE_OBJECTS).union(QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS)
 


### PR DESCRIPTION
Added all of the unqueryable objects found in my testing.

I have added EntityDefinition to the blanket blacklist, but with a note that it only threw on the RecordTypesSupported field. If we add support to remove specific fields from discovery (instead of sync, like attributes), this could be made more granular.