### PR TITLE
move inclusion to metadata, do not select unsupported by default

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -158,9 +158,10 @@ def do_discover(sf):
         compound_properties = [k for k,_ in properties.items() if k in compound_fields]
 
         for prop in compound_properties:
+            metadata.delete(mdata, ('properties', prop), 'selected-by-default')
+
             mdata = metadata.write(mdata, ('properties', prop), 'unsupported-description', 'cannot query compound fields with bulk API')
             mdata = metadata.write(mdata, ('properties', prop), 'inclusion', 'unsupported')
-            mdata = metadata.delete(mdata, ('properties', prop), 'selected-by-default')
 
         schema = {
             'type': 'object',


### PR DESCRIPTION
Fields that emit `selected-by-default` metadata will ultimately be selected unless specifically de-selected. With that said, unsupported fields should not be selected by default as the sync job will fail.