### PR TITLE
Adding more information around quota usage

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -408,9 +408,13 @@ def main_impl():
     finally:
         if sf:
             if sf.rest_requests_attempted > 0:
-                LOGGER.debug("This job used {} REST requests towards the Salesforce quota.".format(sf.rest_requests_attempted))
+                LOGGER.debug(
+                    "This job used %s REST requests towards the Salesforce quota.",
+                    sf.rest_requests_attempted)
             if sf.jobs_completed > 0:
-                LOGGER.debug("Replication used {} Bulk API jobs towards the Salesforce quota.".format(sf.jobs_completed))
+                LOGGER.debug(
+                    "Replication used %s Bulk API jobs towards the Salesforce quota.",
+                    sf.jobs_completed)
             if sf.login_timer:
                 sf.login_timer.cancel()
 


### PR DESCRIPTION
Now logging:

- The name of the object that didn't completely sync in the case of tap termination due to quota.
- The amount of each API that was used per run.
- More verbose information on the amount of quota used/what allotted quota was hit on our side/etc in the case of tap termination due to quota.