### PR TITLE
do not emit metadata for unsupported fields if missing from field list

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -184,7 +184,7 @@ def do_discover(sf):
         if missing_unsupported_field_names:
             LOGGER.info("Ignoring the following unsupported fields for object %s as they are missing from the field list: %s",
                         sobject_name,
-                        ', '.join(sorted([k for k, _ in filtered_unsupported_fields])))
+                        ', '.join(sorted(missing_unsupported_field_names)))
 
         if filtered_unsupported_fields:
             LOGGER.info("Not syncing the following unsupported fields for object %s: %s",


### PR DESCRIPTION
We have found cases where the Salesforce API will reference compound fields in their associated subfields' metadata but not provide them in the overall field list. In such cases, the tap will emit `unsupported` `inclusion` metadata but no schema entry. The proposed fix is to not emit `inclusion` when looping over the unsupported fields.