### PR TITLE
Every field except Id can maybe be nil

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -166,7 +166,7 @@ def field_to_property_schema(field, mdata):
         raise TapSalesforceException("Found unsupported type: {}".format(sf_type))
 
     # The nillable field cannot be trusted
-    if field_name != 'Id'
+    if field_name != 'Id':
         property_schema['type'] = ["null", property_schema['type']]
 
     return property_schema, mdata

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -126,7 +126,6 @@ def field_to_property_schema(field, mdata):
 
     field_name = field['name']
     sf_type = field['type']
-    nillable = field['nillable']
 
     if sf_type in STRING_TYPES:
         property_schema['type'] = "string"
@@ -166,7 +165,8 @@ def field_to_property_schema(field, mdata):
     else:
         raise TapSalesforceException("Found unsupported type: {}".format(sf_type))
 
-    if nillable or sf_type == 'picklist':
+    # The nillable field cannot be trusted
+    if field_name != 'Id'
         property_schema['type'] = ["null", property_schema['type']]
 
     return property_schema, mdata


### PR DESCRIPTION
We've discovered that the `nillable` field on an Object's metadata does not mean anything valuable to our schema generation. Simply accept that any data can be nil except for our required Id field.