### PR TITLE
Only compound Address fields are unsupported by Bulk API

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -94,7 +94,7 @@ def create_property_schema(field, mdata):
 
     property_schema, mdata = salesforce.field_to_property_schema(field, mdata)
 
-    return (property_schema, field['compoundFieldName'], mdata)
+    return (property_schema, mdata)
 
 
 # pylint: disable=too-many-branches,too-many-statements
@@ -148,7 +148,7 @@ def do_discover(sf):
             if field_name == "Id":
                 found_id_field = True
 
-            property_schema, compound_field_name, mdata = create_property_schema(
+            property_schema, mdata = create_property_schema(
                 f, mdata)
 
             # Compound Address fields cannot be queried by the Bulk API

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -152,9 +152,9 @@ def do_discover(sf):
                 f, mdata)
 
             # Compound Address fields cannot be queried by the Bulk API
-            if compound_field_name and "Address" in compound_field_name and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
+            if f['type'] == "address" and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
                 unsupported_fields.add(
-                    (compound_field_name, 'cannot query compound address fields with bulk API'))
+                    (field_name, 'cannot query compound address fields with bulk API'))
 
             # Blacklisted fields are dependent on the api_type being used
             field_pair = (sobject_name, field_name)

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -151,10 +151,10 @@ def do_discover(sf):
             property_schema, compound_field_name, mdata = create_property_schema(
                 f, mdata)
 
-            # Compound fields cannot be queried by the Bulk API
-            if compound_field_name and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
+            # Compound Address fields cannot be queried by the Bulk API
+            if compound_field_name and "Address" in compound_field_name and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:
                 unsupported_fields.add(
-                    (compound_field_name, 'cannot query compound fields with bulk API'))
+                    (compound_field_name, 'cannot query compound address fields with bulk API'))
 
             # Blacklisted fields are dependent on the api_type being used
             field_pair = (sobject_name, field_name)

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -67,6 +67,10 @@ LOOSE_TYPES = set([
 
 # The following objects are not supported by the bulk API.
 UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS = set(['AssetTokenEvent',
+                                               'AttachedContentNote',
+                                               'EventWhoRelation',
+                                               'QuoteTemplateRichTextData',
+                                               'TaskWhoRelation',
                                                'SolutionStatus',
                                                'ContractStatus',
                                                'ContentFolderItem',


### PR DESCRIPTION
A little confusing, but this [Salesforce documentation](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/compound_fields_limitations.htm#compound_fields_limitations) describes Location / Geolocation fields as also only queryable from REST / SOAP but it seems to work after testing.