### PR TITLE
Prevent exceptions during login from killing the thread

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -276,6 +276,7 @@ class Salesforce(object):
 
         LOGGER.info("Attempting login via OAuth2")
 
+        resp = None
         try:
             resp = self.session.post(
                 login_url, data=login_body, headers={"Content-Type": "application/x-www-form-urlencoded"})

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -276,23 +276,23 @@ class Salesforce(object):
 
         LOGGER.info("Attempting login via OAuth2")
 
-        resp = self.session.post(
-            login_url, data=login_body, headers={
-                "Content-Type": "application/x-www-form-urlencoded"})
-
         try:
+            resp = self.session.post(
+                login_url, data=login_body, headers={"Content-Type": "application/x-www-form-urlencoded"})
+
             resp.raise_for_status()
+
+            LOGGER.info("OAuth2 login successful")
+
+            auth = resp.json()
+
+            self.access_token = auth['access_token']
+            self.instance_url = auth['instance_url']
         except Exception as e:
             raise Exception(str(e) + ", Response from Salesforce: {}".format(resp.text)) from e
-
-        LOGGER.info("OAuth2 login successful")
-
-        auth = resp.json()
-
-        self.access_token = auth['access_token']
-        self.instance_url = auth['instance_url']
-        self.login_timer = threading.Timer(REFRESH_TOKEN_EXPIRATION_PERIOD, self.login)
-        self.login_timer.start()
+        finally:
+            self.login_timer = threading.Timer(REFRESH_TOKEN_EXPIRATION_PERIOD, self.login)
+            self.login_timer.start()
 
     def describe(self, sobject=None):
         """Describes all objects or a specific object"""

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -289,7 +289,10 @@ class Salesforce(object):
             self.access_token = auth['access_token']
             self.instance_url = auth['instance_url']
         except Exception as e:
-            raise Exception(str(e) + ", Response from Salesforce: {}".format(resp.text)) from e
+            error_message = str(e)
+            if resp:
+                error_message = error_message + ", Response from Salesforce: {}".format(resp.text)
+            raise Exception(error_message) from e
         finally:
             self.login_timer = threading.Timer(REFRESH_TOKEN_EXPIRATION_PERIOD, self.login)
             self.login_timer.start()


### PR DESCRIPTION
Don't let an exception during the `POST` to kill the thread and prevent it from executing another login.