### PR TITLE
Replace null bytes with '' when encountered in the SF data

### DIFF
--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -230,7 +230,9 @@ class Bulk(object):
                 timer.tags['sobject'] = catalog_entry['stream']
                 result_response = self.sf._make_request('GET', url, headers=headers, stream=True)
 
-            csv_stream = csv.reader(self._iter_lines(result_response),
+            # Starting with a streaming generator, replace any NULL bytes in the line given by the CSV reader
+            streaming_response = self._iter_lines(result_response)
+            csv_stream = csv.reader((line.replace('\0', '') for line in streaming_response),
                                     delimiter=',',
                                     quotechar='"')
 


### PR DESCRIPTION
Depending on the Salesforce field, it is possible to copy/paste or enter NULL bytes `\0` into a Salesforce field. When output by the SF API, this data will poison the Python CSV reader with an error: 

```
csv.Error: line contains NULL byte
```

To fix this error, we can replace the null bytes with empty strings which will allow us to proceed without much modification to the data.

To find null bytes in the data, you can use sed piped to cat: `sed -n '/\x0/p' data.csv | cat -v`