### PR TITLE
Add more logging and save state during normal chunked bulk sync

### DIFF
--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -92,8 +92,11 @@ class Bulk(object):
                 for completed_batch_id in batch_status['completed']:
                     for result in self.get_batch_results(job_id, completed_batch_id, catalog_entry):
                         yield result
-                    # Remove the completed batch ID
+                    # Remove the completed batch ID and write state
                     state['bookmarks'][catalog_entry['tap_stream_id']]["BatchIDs"].remove(completed_batch_id)
+                    LOGGER.info("Finished syncing batch %s. Removing batch from state.", completed_batch_id)
+                    LOGGER.info("Batches to go: %d", len(state['bookmarks'][catalog_entry['tap_stream_id']]["BatchIDs"]))
+                    singer.write_state(state)
 
             raise TapSalesforceException(batch_status['stateMessage'])
         else:

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -75,6 +75,8 @@ def resume_syncing_bulk_query(sf, catalog_entry, job_id, state, counter):
                                           'JobHighestBookmarkSeen',
                                           singer_utils.strftime(current_bookmark))
             batch_ids.remove(batch_id)
+            LOGGER.info("Finished syncing batch %s. Removing batch from state.", batch_id)
+            LOGGER.info("Batches to go: %d", len(batch_ids))
             singer.write_state(state)
 
     return counter


### PR DESCRIPTION
Fixes a few more issues:

* Add more logging to show how far along we've gotten
* Call `write_state` during the normal sync whenever we finish syncing a batch and remove it. 