### PR TITLE
Simplify error handling for http errors

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -275,7 +275,7 @@ class Salesforce(object):
         try:
             resp.raise_for_status()
         except RequestException as ex:
-            raise TapSalesforceHTTPException(ex) from ex
+            raise TapSalesforceHTTPException("Error response from Salesforce") from ex
 
         if resp.headers.get('Sforce-Limit-Info') is not None:
             self.rest_requests_attempted += 1

--- a/tap_salesforce/salesforce/exceptions.py
+++ b/tap_salesforce/salesforce/exceptions.py
@@ -9,9 +9,4 @@ class TapSalesforceQuotaExceededException(TapSalesforceException):
 
 
 class TapSalesforceHTTPException(TapSalesforceException):
-    def __init__(self, requestException):
-        self.requestException = requestException
-
-    def __str__(self):
-        return str(self.requestException) + \
-            ", Response from Salesforce: {}".format(self.requestException.response.text)
+    pass

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -4,7 +4,6 @@ import singer.metrics as metrics
 import singer.utils as singer_utils
 from singer import Transformer
 from tap_salesforce.salesforce.bulk import Bulk
-from tap_salesforce.salesforce.exceptions import TapSalesforceException
 
 LOGGER = singer.get_logger()
 
@@ -88,13 +87,9 @@ def sync_stream(sf, catalog_entry, state):
         try:
             sync_records(sf, catalog_entry, state, counter)
             singer.write_state(state)
-        except TapSalesforceException as ex:
-            raise type(ex)("Error syncing {}: {}".format(
-                stream, ex))
         except Exception as ex:
-            raise Exception(
-                "Unexpected error syncing {}: {}".format(
-                    stream, ex)) from ex
+            raise Exception("Error syncing {}: {}".format(
+                stream, ex)) from ex
 
         return counter
 


### PR DESCRIPTION
Fixes a bug that looks like:

```
2018-02-07 10:09:47,268Z    tap -   File "/code/python3.5/site-packages/tap_salesforce/salesforce/exceptions.py", line 17, in __str__
2018-02-07 10:09:47,268Z    tap -     ", Response from Salesforce: {}".format(self.requestException.response.text)
2018-02-07 10:09:47,268Z    tap - AttributeError: 'str' object has no attribute 'response'
```