### PR TITLE
Add configuration option to automatically select all fields and streams

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,10 +3,11 @@ image: python:latest
 before_script:
   - python -V
   - python -m venv venv
-  - . venv/bin/activate
+  - source venv/bin/activate
+  - python setup install
 
 test:
   script:
-  - python setup.py test
+  - python setup test
   - pip install pylint
   - pylint tap_salesforce -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,10 +4,10 @@ before_script:
   - python -V
   - python -m venv venv
   - source venv/bin/activate
-  - python setup install
 
 test:
   script:
-  - python setup test
+  - python setup.py install
+  - python setup.py test
   - pip install pylint
   - pylint tap_salesforce -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+image: python:latest
+
+before_script:
+  - python -V
+  - python -m venv venv
+  - . venv/bin/activate
+
+test:
+  script:
+  - python setup.py test
+  - pip install pylint
+  - pylint tap_salesforce -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -165,9 +165,14 @@ def do_discover(sf):
             inclusion = metadata.get(
                 mdata, ('properties', field_name), 'inclusion')
 
-            if sf.select_fields_by_default and inclusion != 'unsupported':
-                mdata = metadata.write(
-                    mdata, ('properties', field_name), 'selected-by-default', True)
+            if inclusion != 'unsupported':
+                if sf.select_fields_by_default:
+                    mdata = metadata.write(
+                        mdata, ('properties', field_name), 'selected-by-default', True)
+
+                if sf.force_select_all:
+                    mdata = metadata.write(
+                        mdata, ('properties', field_name), 'selected', True)
 
             properties[field_name] = property_schema
 
@@ -224,6 +229,10 @@ def do_discover(sf):
                     'reason': 'No replication keys found from the Salesforce API'})
 
         mdata = metadata.write(mdata, (), 'table-key-properties', key_properties)
+
+        if sf.force_select_all:
+            mdata = metadata.write(
+                mdata, (), 'selected', True)
 
         schema = {
             'type': 'object',
@@ -350,7 +359,8 @@ def main_impl():
             is_sandbox=CONFIG.get('is_sandbox'),
             select_fields_by_default=CONFIG.get('select_fields_by_default'),
             default_start_date=CONFIG.get('start_date'),
-            api_type=CONFIG.get('api_type'))
+            api_type=CONFIG.get('api_type'),
+            force_select_all=CONFIG.get('force_select_all'))
         sf.login()
 
         if args.discover:

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -197,7 +197,8 @@ class Salesforce(object):
                  is_sandbox=None,
                  select_fields_by_default=None,
                  default_start_date=None,
-                 api_type=None):
+                 api_type=None,
+                 force_select_all=None):
         self.api_type = api_type.upper() if api_type else None
         self.refresh_token = refresh_token
         self.token = token
@@ -212,6 +213,7 @@ class Salesforce(object):
             quota_percent_total) if quota_percent_total is not None else 80
         self.is_sandbox = is_sandbox is True or (isinstance(is_sandbox, str) and is_sandbox.lower() == 'true')
         self.select_fields_by_default = select_fields_by_default is True or (isinstance(select_fields_by_default, str) and select_fields_by_default.lower() == 'true')
+        self.force_select_all = force_select_all is True or (isinstance(force_select_all, str) and force_select_all.lower() == 'true')
         self.default_start_date = default_start_date
         self.rest_requests_attempted = 0
         self.jobs_completed = 0


### PR DESCRIPTION
The current design seems to be against this, but if the tap is only to be used as an extraction step, it seems easier to blacklist fields than enable all of them.

The configuration `force_select_all` will:
  - Mark all streams as `selected: true`
  - Mark all properties as `selected: true`

 