### PR TITLE
add FieldHistory suffix to find_parent function

### DIFF
--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -23,6 +23,8 @@ def find_parent(stream):
     parent_stream = stream
     if stream.endswith("CleanInfo"):
         parent_stream = stream[:stream.find("CleanInfo")]
+    elif stream.endswith("FieldHistory"):
+        parent_stream = stream[:stream.find("FieldHistory")]
     elif stream.endswith("History"):
         parent_stream = stream[:stream.find("History")]
 


### PR DESCRIPTION
The `OpportunityFieldHistory` export was failing since the `find_parent()` function was finding the suffix `History`, and returning the parent as `OpportunityField`.  

This PR adds a check for the suffix `FieldHistory` (before looking for `History`) so that `Opportunity` is correctly returned as the parent.