### PR TITLE
Fix format for date field on example config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ tap-salesforce --config config.json --properties properties.json --state state
   "client_id": "secret_client_id",
   "client_secret": "secret_client_secret",
   "refresh_token": "abc123",
-  "start_date": "2017-11-02",
+  "start_date": "2017-11-02T00:00:00Z",
   "api_type": "BULK",
   "select_fields_by_default": true
 }


### PR DESCRIPTION
Running `tap-salesforce --config config.json --discover` with the `date` format from the example config raises an error, it's a pretty straight forward formatting error, still it'd be nice if the correct format was in the README :)

For good measure, this is the output of the above command

```
$ tap-salesforce --config config.json --discover
CRITICAL time data '2017-11-02' does not match format '%Y-%m-%dT%H:%M:%SZ'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/singer/utils.py", line 28, in strptime
    return datetime.datetime.strptime(dtime, DATETIME_FMT)
  File "/usr/local/lib/python3.7/_strptime.py", line 577, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.7/_strptime.py", line 351, in _strptime
    (bad_directive, format)) from None
ValueError: '0' is a bad directive in format '%04Y-%m-%dT%H:%M:%S.%fZ'```