### PR TITLE
Remove invalid job ids from state

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -306,7 +306,8 @@ def do_sync(sf, catalog, state):
                 counter = resume_syncing_bulk_query(sf, catalog_entry, job_id, state, counter)
                 LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter.value)
                 # Remove Job info from state once we complete this resumed query. One of a few cases could have occurred:
-                # 1. The job succeeded, in which case make JobHighestBookmarkSeen the new bookmark
+                # 1. The job succeeded, in which case make JobHighestBookmarkSeen the new bookmark, or existing bookmark
+                #    if no bookmark exists for the Job.
                 # 2. The job partially completed, in which case make JobHighestBookmarkSeen the new bookmark
                 # 3. The job completely failed, in which case maintain the existing bookmark, or None
                 state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}).pop('JobID', None)

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -305,6 +305,10 @@ def do_sync(sf, catalog, state):
                 # Resuming a sync should clear out the remaining state once finished
                 counter = resume_syncing_bulk_query(sf, catalog_entry, job_id, state, counter)
                 LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter.value)
+                # Remove Job info from state once we complete this resumed query. One of a few cases could have occurred:
+                # 1. The job succeeded, in which case make JobHighestBookmarkSeen the new bookmark
+                # 2. The job partially completed, in which case make JobHighestBookmarkSeen the new bookmark
+                # 3. The job completely failed, in which case maintain the existing bookmark, or None
                 state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}).pop('JobID', None)
                 state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}).pop('BatchIDs', None)
                 bookmark = state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}) \

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -306,10 +306,10 @@ def do_sync(sf, catalog, state):
                 counter = resume_syncing_bulk_query(sf, catalog_entry, job_id, state, counter)
                 LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter.value)
                 # Remove Job info from state once we complete this resumed query. One of a few cases could have occurred:
-                # 1. The job succeeded, in which case make JobHighestBookmarkSeen the new bookmark, or existing bookmark
-                #    if no bookmark exists for the Job.
-                # 2. The job partially completed, in which case make JobHighestBookmarkSeen the new bookmark
-                # 3. The job completely failed, in which case maintain the existing bookmark, or None
+                # 1. The job succeeded, in which case make JobHighestBookmarkSeen the new bookmark
+                # 2. The job partially completed, in which case make JobHighestBookmarkSeen the new bookmark, or
+                #    existing bookmark if no bookmark exists for the Job.
+                # 3. The job completely failed, in which case maintain the existing bookmark, or None if no bookmark
                 state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}).pop('JobID', None)
                 state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}).pop('BatchIDs', None)
                 bookmark = state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}) \

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -307,12 +307,15 @@ def do_sync(sf, catalog, state):
                 LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter.value)
                 state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}).pop('JobID', None)
                 state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}).pop('BatchIDs', None)
-                bookmark = state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}).pop('JobHighestBookmarkSeen', None)
+                bookmark = state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}) \
+                                                     .pop('JobHighestBookmarkSeen', None)
+                existing_bookmark = state.get('bookmarks', {}).get(catalog_entry['tap_stream_id'], {}) \
+                                                              .pop(replication_key, None)
                 state = singer.write_bookmark(
                     state,
                     catalog_entry['tap_stream_id'],
                     replication_key,
-                    bookmark)
+                    bookmark or existing_bookmark) # If job is removed, reset to existing bookmark or None
                 singer.write_state(state)
         else:
             # Tables with a replication_key or an empty bookmark will emit an

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -229,10 +229,10 @@ class Bulk():
             return True # requests will raise for a 400 InvalidJob
 
         except RequestException as ex:
-            exception_code = xmltodict.parse(ex.response.text,
-                                             xml_attribs=False)['error']['exceptionCode']
-            if exception_code == 'InvalidJob':
-                return False
+            if ex.response.headers["Content-Type"] == 'application/json':
+                exception_code = ex.response.json()['exceptionCode']
+                if exception_code == 'InvalidJob':
+                    return False
             raise
 
     def _get_batches(self, job_id):

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -224,16 +224,14 @@ class Bulk():
             headers = self._get_bulk_headers()
 
             with metrics.http_request_timer("get_job"):
-                resp = self.sf._make_request('GET', url, headers=headers)
+                self.sf._make_request('GET', url, headers=headers)
 
             return True # requests will raise for a 400 InvalidJob
 
         except RequestException as ex:
-            root = minidom.parseString(res.response.text)
-            exception_code = xmltodict.parse(res.response.text,
+            exception_code = xmltodict.parse(ex.response.text,
                                              xml_attribs=False)['error']['exceptionCode']
             if exception_code == 'InvalidJob':
-                # Remove the job and set it up to try again.
                 return False
             raise
 

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -54,6 +54,10 @@ def resume_syncing_bulk_query(sf, catalog_entry, job_id, state, counter):
     stream_version = get_stream_version(catalog_entry, state)
     schema = catalog_entry['schema']
 
+    if not bulk.job_exists(job_id):
+        LOGGER.info("Found stored Job ID that no longer exists, resetting bookmark and removing JobID from state.")
+        return counter
+
     # Iterate over the remaining batches, removing them once they are synced
     for batch_id in batch_ids[:]:
         for rec in bulk.get_batch_results(job_id, batch_id, catalog_entry):


### PR DESCRIPTION
If a sync runs incompletely, and saves a job ID that it was waiting on, then the Job isn't requested for some time, it will be deleted from Salesforce.

This PR is to detect this case, save bookmarks as-is, remove the JobID/BatchIDs from the state, then move on.