### PR TITLE
Fix/background operation result full table

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -34,7 +34,7 @@ def get_replication_key(sobject_name, fields):
         return 'SystemModstamp'
     elif 'LastModifiedDate' in fields_list:
         return 'LastModifiedDate'
-    elif 'CreatedDate' in fields_list:
+    elif 'CreatedDate' in fields_list and sobject_name != 'BackgroundOperationResult':
         return 'CreatedDate'
     elif 'LoginTime' in fields_list and sobject_name == 'LoginHistory':
         return 'LoginTime'

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -27,14 +27,21 @@ CONFIG = {
     'start_date': None
 }
 
+FORCED_FULL_TABLE = {
+    'BackgroundOperationResult' # Does not support ordering by CreatedDate
+}
+
 def get_replication_key(sobject_name, fields):
+    if sobject_name in FORCED_FULL_TABLE:
+        return None
+
     fields_list = [f['name'] for f in fields]
 
     if 'SystemModstamp' in fields_list:
         return 'SystemModstamp'
     elif 'LastModifiedDate' in fields_list:
         return 'LastModifiedDate'
-    elif 'CreatedDate' in fields_list and sobject_name != 'BackgroundOperationResult':
+    elif 'CreatedDate' in fields_list:
         return 'CreatedDate'
     elif 'LoginTime' in fields_list and sobject_name == 'LoginHistory':
         return 'LoginTime'


### PR DESCRIPTION
The object BackgroundOperationResult does not support ordering by `CreatedDate`, so this must be requested in a `FULL_TABLE` manner.