### PR TITLE
fix discovering replication-key

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -227,7 +227,7 @@ def do_discover(sf):
 
         if replication_key:
             mdata = metadata.write(
-                mdata, (), 'valid-replication-keys', [replication_key])
+                mdata, (), 'replication-key', replication_key)
         else:
             mdata = metadata.write(
                 mdata,


### PR DESCRIPTION
**PROBLEM**:

Salesforce tap doesn't write state file correctly when INCREMENTAL load is selected. The output is a valid JSON but doesn't include the incremental values:
```
{"type": "STATE", "value": {"current_stream": null, "bookmarks": {"Contact": {"version": null}, "Lead": {"version": null}, "User": {"version": null}, "Opportunity": {"version": null}, "Account": {"version": null}}}}
```

**REASON**:
Discovery mode writes replication-key into `properties.json` in the format: `"valid-replication-keys": ["SystemModstamp"]`

But, do_sync function expecting a different format when extracting the incremental value: `"replication-key": SystemModstamp`

Also, `valid-replication-keys` keyword is not used anywhere in the code.


**FIX**:
Modifying do_discovery to write replication-key into properties.json in the expected format 

Interestingly this possibly incorrect behaviour was introduced long time ago in tap-salesforce:
https://github.com/singer-io/tap-salesforce/commit/41b3e5521015a6b5455f0324815d8634d3d8b381#diff-73edc540bc186bf0bff6c0442ff78d4f
