### PR TITLE
Mark Announcement as query-incompatible

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -151,7 +151,6 @@ def do_discover(sf):
         # Loop over the object's fields
         for f in fields:
             field_name = f['name']
-            field_type = f['type']
 
             if field_name == "Id":
                 found_id_field = True

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -130,7 +130,7 @@ def log_backoff_attempt(details):
     LOGGER.info("ConnectionError detected, triggering backoff: %d try", details.get("tries"))
 
 
-def field_to_property_schema(field, mdata):
+def field_to_property_schema(field, mdata): # pylint:disable=too-many-branches
     property_schema = {}
 
     field_name = field['name']

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -82,7 +82,8 @@ UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS = set(['AssetTokenEvent',
                                                'UndecidedEventRelation'])
 
 # The following objects have certain WHERE clause restrictions so we exclude them.
-QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(['ContentDocumentLink',
+QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(['Announcement',
+                                           'ContentDocumentLink',
                                            'CollaborationGroupRecord',
                                            'Vote',
                                            'IdeaComment',


### PR DESCRIPTION
We've observed that Announcement returns this message when attempting to sync using a SOQL query.

```
InvalidBatch : Failed to process query: MALFORMED_QUERY: Implementation restriction: Announcement requires a filter by an ID, FeedItemId or ParentId using the equals operator.
```

This indicates that it isn't fit for replication without significant additions to the tap's structure (e.g., syncing it by `ParentId`, if it's possible to find a direct Parent link through the API). Because of this, the PR adds it to the blacklist, removing it from availability. See [Blacklisting.md](https://github.com/singer-io/tap-salesforce/blob/master/Blacklisting.md) for more info.