### PR TITLE
Put more information into error message for login failures

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -312,7 +312,8 @@ class Salesforce():
             self.instance_url = auth['instance_url']
         except Exception as e:
             error_message = str(e)
-            if resp:
+            # NB: requests.models.Response is always falsy here. It is false if status code >= 400
+            if resp is not None or e.response is not None:
                 error_message = error_message + ", Response from Salesforce: {}".format(resp.text)
             raise Exception(error_message) from e
         finally:

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -312,8 +312,10 @@ class Salesforce():
             self.instance_url = auth['instance_url']
         except Exception as e:
             error_message = str(e)
+            if resp is None and hasattr(e, 'response') and e.response is not None:
+                resp = e.response
             # NB: requests.models.Response is always falsy here. It is false if status code >= 400
-            if resp is not None or e.response is not None:
+            if isinstance(resp, requests.models.Response):
                 error_message = error_message + ", Response from Salesforce: {}".format(resp.text)
             raise Exception(error_message) from e
         finally:

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -312,8 +312,8 @@ class Salesforce():
             self.instance_url = auth['instance_url']
         except Exception as e:
             error_message = str(e)
-            if resp is None and hasattr(e, 'response') and e.response is not None:
-                resp = e.response
+            if resp is None and hasattr(e, 'response') and e.response is not None: #pylint:disable=no-member
+                resp = e.response #pylint:disable=no-member
             # NB: requests.models.Response is always falsy here. It is false if status code >= 400
             if isinstance(resp, requests.models.Response):
                 error_message = error_message + ", Response from Salesforce: {}".format(resp.text)


### PR DESCRIPTION
Turns out that response objects are always falsy if the status_code is >= 400. This PR extends our error handling code to add more info if the login raises an exception (e.g., inactive user)