### PR TITLE
Convert '0.0' to '0' if field can be an integer

### DIFF
--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -18,6 +18,12 @@ def transform_bulk_data_hook(data, typ, schema):
     if isinstance(data, dict):
         result = remove_blacklisted_fields(data)
 
+    # Salesforce can return the value '0.0' for integer typed fields. This
+    # causes a schema violation. Convert it to '0' if schema['type'] has
+    # integer.
+    if data == '0.0' and 'integer' in schema.get('type', []):
+        result = '0'
+
     # Salesforce Bulk API returns CSV's with empty strings for text fields.
     # When the text field is nillable and the data value is an empty string,
     # change the data so that it is None.


### PR DESCRIPTION
Sometimes Salesforce returns an integer field with a value of '0.0' (which is clearly a float). Since this is equivalent, and according to the schema generation code [here](https://github.com/singer-io/tap-salesforce/blob/master/tap_salesforce/salesforce/__init__.py#L133-L188) the tap won't generate a schema with ***both*** `number` and `integer`. We can safely convert this to an "integer" zero value in this case.