### PR TITLE
Query bulk during discovery

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -118,6 +118,7 @@ def do_discover(sf):
     # For each SF Object describe it, loop its fields and build a schema
     entries = []
 
+    # Check if the user has BULK API enabled
     if sf.api_type == 'BULK':
         try:
             bulk = Bulk(sf)

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 import json
 import sys
+import requests
 import singer
 import singer.utils as singer_utils
 from singer import metadata, metrics
 import tap_salesforce.salesforce
-import requests
 from tap_salesforce.sync import (sync_stream, resume_syncing_bulk_query, get_stream_version)
 from tap_salesforce.salesforce import Salesforce
 from tap_salesforce.salesforce.bulk import Bulk

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -9,7 +9,7 @@ from tap_salesforce.sync import (sync_stream, resume_syncing_bulk_query, get_str
 from tap_salesforce.salesforce import Salesforce
 from tap_salesforce.salesforce.bulk import Bulk
 from tap_salesforce.salesforce.exceptions import (
-    TapSalesforceException, TapSalesforceQuotaExceededException)
+    TapSalesforceException, TapSalesforceQuotaExceededException, TapSalesforceBulkAPIDisabledException)
 
 LOGGER = singer.get_logger()
 
@@ -118,8 +118,8 @@ def do_discover(sf):
     entries = []
 
     # Check if the user has BULK API enabled
-    if sf.api_type == 'BULK':
-        Bulk(sf).check_permissions()
+    if sf.api_type == 'BULK' and not Bulk(sf).has_permissions():
+        raise TapSalesforceBulkAPIDisabledException('This client does not have Bulk API permissions, received "API_DISABLED_FOR_ORG" error code')
 
     for sobject_name in objects_to_discover:
 

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -47,14 +47,15 @@ class Bulk():
         csv.field_size_limit(sys.maxsize)
         self.sf = sf
 
-    def check_permissions(self):
+    def has_permissions(self):
         try:
             self.check_bulk_quota_usage()
         except requests.exceptions.HTTPError as err:
-            if err.response is not None and len(err.response.json()) > 0:
+            if err.response is not None:
                 for error_response_item in err.response.json():
                     if error_response_item.get('errorCode') == 'API_DISABLED_FOR_ORG':
-                        raise TapSalesforceBulkAPIDisabledException('This client does not have Bulk API permissions, received "API_DISABLED_FOR_ORG" error code')
+                        return False
+        return True
 
     def query(self, catalog_entry, state):
         self.check_bulk_quota_usage()

--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -12,7 +12,7 @@ from requests.exceptions import RequestException
 import xmltodict
 
 from tap_salesforce.salesforce.exceptions import (
-    TapSalesforceException, TapSalesforceQuotaExceededException, TapSalesforceBulkAPIDisabledException)
+    TapSalesforceException, TapSalesforceQuotaExceededException)
 
 BATCH_STATUS_POLLING_SLEEP = 20
 PK_CHUNKED_BATCH_STATUS_POLLING_SLEEP = 60

--- a/tap_salesforce/salesforce/exceptions.py
+++ b/tap_salesforce/salesforce/exceptions.py
@@ -3,6 +3,8 @@
 class TapSalesforceException(Exception):
     pass
 
-
 class TapSalesforceQuotaExceededException(TapSalesforceException):
+    pass
+
+class TapSalesforceBulkAPIDisabledException(TapSalesforceException):
     pass

--- a/tap_salesforce/salesforce/rest.py
+++ b/tap_salesforce/salesforce/rest.py
@@ -101,5 +101,5 @@ class Rest():
 
             if next_records_url is None:
                 break
-            else:
-                url = "{}{}".format(self.sf.instance_url, next_records_url)
+
+            url = "{}{}".format(self.sf.instance_url, next_records_url)


### PR DESCRIPTION
Since `api_type` is immutable, the tap should fail during discovery if the user selected `BULK` but doesn't have permissions.  Otherwise, the tap fails during sync mode, and since the user cannot change `api_type`, they have to recreate the connection.

The fix is to try and check the bulk quota usage at the beginning of discovery, which returns a 403 if the user doesn't have `BULK` permissions.  