### PR TITLE
Add nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,3 +33,18 @@ jobs:
                        --password=$SANDBOX_PASSWORD \
                        --client-id=50 \
                        tap_tester.suites.salesforce
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build


### PR DESCRIPTION
# Description of change
Salesforce has a limit of 5 authorizations be user. So our integration tests, when run nightly would fail. The tests will now use a distinct user to run, so we are reinstating the nightly integration test runs.

# QA steps
 - [ ] automated tests passing
 - [X] manual qa steps passing (list below)
    - Checked to make sure that the credentials work in the latest master workflow run on Circle
 
# Risks
Low, the tests are currently non-functional.

# Rollback steps
 - revert this branch
