### PR TITLE
Force LoginEvent to do full table replication

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -28,7 +28,8 @@ CONFIG = {
 }
 
 FORCED_FULL_TABLE = {
-    'BackgroundOperationResult' # Does not support ordering by CreatedDate
+    'BackgroundOperationResult', # Does not support ordering by CreatedDate
+    'LoginEvent', # Does not support ordering by CreatedDate
 }
 
 def get_replication_key(sobject_name, fields):


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-1432

Add LoginEvent to the list of forced full table streams.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
Low - key based replication for this stream does not work so forcing full table on it should be risk free. The forced-full table code is also preexisting so there should not be any risk in it.

# Rollback steps
 - revert this branch
