### PR TITLE
Avoid "int too large to convert to C long" error on Windows OS

### DIFF
--- a/tap_salesforce/salesforce/bulk.py
+++ b/tap_salesforce/salesforce/bulk.py
@@ -44,7 +44,7 @@ class Bulk():
 
     def __init__(self, sf):
         # Set csv max reading size to the platform's max size available.
-        csv.field_size_limit(sys.maxsize)
+        csv.field_size_limit(min(sys.maxsize, 2**31))
         self.sf = sf
 
     def has_permissions(self):


### PR DESCRIPTION
# Description of change
The tap will not run on windows OS due to a memory overflow. Running `tap-salesforce -c <config> --discover` results in the error *OverflowError: Python int too large to convert to C long*

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
