### PR TITLE
Add DataType stream to our QUERY_INCOMPATIBLE set

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -104,7 +104,8 @@ QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(['Announcement',
                                            'FlexQueueItem'])
 
 # The following objects are not supported by the query method being used.
-QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['ListViewChartInstance',
+QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['DataType',
+                                             'ListViewChartInstance',
                                              'FeedLike',
                                              'OutgoingEmail',
                                              'OutgoingEmailRelation',


### PR DESCRIPTION
# Description of change

According to the Salesforce docs, the DataType object does not support a LIMIT clause.

https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_datatype.htm

For now, we should mark this stream as unsupported until we modify how the tap issues queries.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
