### PR TITLE
Raise MAX_RETRIES to 8

### DIFF
--- a/tap_salesforce/salesforce/rest.py
+++ b/tap_salesforce/salesforce/rest.py
@@ -6,7 +6,7 @@ from tap_salesforce.salesforce.exceptions import TapSalesforceException
 
 LOGGER = singer.get_logger()
 
-MAX_RETRIES = 4
+MAX_RETRIES = 8
 
 class Rest():
 


### PR DESCRIPTION
# Description of change

Setting MAX_RETRIES to use a higher default so it can divide the date range more times before running out.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
