### PR TITLE
added NetworkUserHistoryRecent to blacklist

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -101,7 +101,8 @@ QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(['Announcement',
                                            'UserFieldAccess',
                                            'PicklistValueInfo',
                                            'RelationshipDomain',
-                                           'FlexQueueItem'])
+                                           'FlexQueueItem',
+                                           'NetworkUserHistoryRecent'])
 
 # The following objects are not supported by the query method being used.
 QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['DataType',

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -103,8 +103,8 @@ def sync_stream(sf, catalog_entry, state):
             sync_records(sf, catalog_entry, state, counter)
             singer.write_state(state)
         except RequestException as ex:
-            raise Exception("Error syncing {}: {} Response: {}".format(# pylint: disable=raise-missing-from
-                stream, ex, ex.response.text))
+            raise Exception("Error syncing {}: {} Response: {}".format(
+                stream, ex, ex.response.text)) from ex
         except Exception as ex:
             raise Exception("Error syncing {}: {}".format(
                 stream, ex)) from ex

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -102,8 +102,8 @@ def sync_stream(sf, catalog_entry, state):
         try:
             sync_records(sf, catalog_entry, state, counter)
             singer.write_state(state)
-        except RequestException as ex: # pylint: disable=raise-missing-from
-            raise Exception("Error syncing {}: {} Response: {}".format(
+        except RequestException as ex:
+            raise Exception("Error syncing {}: {} Response: {}".format(# pylint: disable=raise-missing-from
                 stream, ex, ex.response.text))
         except Exception as ex:
             raise Exception("Error syncing {}: {}".format(

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -102,7 +102,7 @@ def sync_stream(sf, catalog_entry, state):
         try:
             sync_records(sf, catalog_entry, state, counter)
             singer.write_state(state)
-        except RequestException as ex:
+        except RequestException as ex: # pylint: disable=raise-missing-from
             raise Exception("Error syncing {}: {} Response: {}".format(
                 stream, ex, ex.response.text))
         except Exception as ex:


### PR DESCRIPTION
# Description of change
added NetworkUserHistoryRecent to blacklist
https://stitchdata.atlassian.net/secure/RapidBoard.jspa?rapidView=23&modal=detail&selectedIssue=SUP-1797

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
- ran discovery with cloned connection of  client that was previously getting an error that had to do with object not being supported. stream was no longer written to catalog
 
# Risks
 - low
# Rollback steps
 - revert this branch
