### PR TITLE
updated error message for OPERATION_TOO_LARGE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-salesforce',
       py_modules=['tap_salesforce'],
       install_requires=[
           'requests==2.20.0',
-          'singer-python==5.3.1',
+          'singer-python==5.10.0',
           'xmltodict==0.11.0'
       ],
       entry_points='''

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -2,6 +2,7 @@ import time
 import singer
 import singer.utils as singer_utils
 from singer import Transformer, metadata, metrics
+from singer import SingerSyncError
 from requests.exceptions import RequestException
 from tap_salesforce.salesforce.bulk import Bulk
 
@@ -106,6 +107,10 @@ def sync_stream(sf, catalog_entry, state):
             raise Exception("{} Response: {}, (Stream: {})".format(
                 ex, ex.response.text, stream)) from ex
         except Exception as ex:
+            if "OPERATION_TOO_LARGE: exceeded 100000 distinct who/what's" in str(ex):
+                raise SingerSyncError("OPERATION_TOO_LARGE: exceeded 100000 distinct who/what's. " +
+                                      "Consider asking your Salesforce System Administrator to provide you with the " +
+                                      "`View All Data` profile permission. (Stream: {})".format(stream)) from ex
             raise Exception("{}, (Stream: {})".format(
                 ex, stream)) from ex
 


### PR DESCRIPTION
# Description of change
changed error message for `InvalidBatch : Failed to process query: OPERATION_TOO_LARGE: exceeded 100000 distinct who/what's` to be actionable, and wrapped it in a SingerSyncError. 

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 - manually raised exception with the same error message
# Risks
low
# Rollback steps
 - revert this branch
