### PR TITLE
Remove support for `FieldHistoryArchive`

### DIFF
--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -102,7 +102,8 @@ QUERY_RESTRICTED_SALESFORCE_OBJECTS = set(['Announcement',
                                            'PicklistValueInfo',
                                            'RelationshipDomain',
                                            'FlexQueueItem',
-                                           'NetworkUserHistoryRecent'])
+                                           'NetworkUserHistoryRecent',
+                                           'FieldHistoryArchive',])
 
 # The following objects are not supported by the query method being used.
 QUERY_INCOMPATIBLE_SALESFORCE_OBJECTS = set(['DataType',


### PR DESCRIPTION
# Long commit message
The tap encountered 
```InvalidBatch: Failed to process query:
BIG_OBJECT_UNSUPPORTED_OPERATION: Filters may not have any gaps within the composite key
```

The current shape of the WHERE + ORDER BY clauses:

```
WHERE replication_key >= some_date ORDER BY replication_key ASC
```

But `FieldHistoryArchive` seems to need something along these lines (note
CreatedDate is the replication key)

```
WHERE FieldHistoryType = 'ACCOUNT'
```

```
WHERE FieldHistoryType = 'ACCOUNT' AND CreatedDate >= 2020-01-01T00:00:00Z
```

```
WHERE FieldHistoryType = 'ACCOUNT' AND CreatedDate >= 2019-01-01T00:00:00Z
ORDER BY FieldHistoryType ASC, CreatedDate DESC
```
- Note the `DESC` here

# Description of change
This PR adds `FieldHistoryArchive` to the list of streams we don't support because it needs a different `WHERE` clause than the one we generate.

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
     - Ran the tap with and without this commit, verifying that `FieldHistoryArchive` does not show up in the catalog with this commit
 
# Risks
- Does removing support for a stream count as a breaking change? Maybe not in this case because it was never working for anyone

# Rollback steps
 - revert this branch
