### PR TITLE
move build time, use tap_tester_sandbox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           when: always
           name: 'Integration Tests'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-salesforce \
@@ -54,7 +54,7 @@ workflows:
   build_daily:
     triggers:
       - schedule:
-          cron: "0 13 * * *"
+          cron: "0 6 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
# Description of change
Move build time to avoid collisions and use tap_tester_sandbox env.
# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
