### PR TITLE
Change Salesforce login to fail after backing off 3 times

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(name='tap-salesforce',
       install_requires=[
           'requests==2.20.0',
           'singer-python==5.10.0',
-          'xmltodict==0.11.0'
+          'xmltodict==0.11.0',
+          'nose'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -293,6 +293,9 @@ class Salesforce():
 
         return resp
 
+    def attempt_login(self):
+        print("hey there")
+
     def login(self):
         if self.is_sandbox:
             login_url = 'https://test.salesforce.com/services/oauth2/token'

--- a/tests/unittests/test_auth_failure.py
+++ b/tests/unittests/test_auth_failure.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import Mock
+from tap_salesforce import Salesforce
+
+class TestAuthorizationHandling(unittest.TestCase):
+    def test_attempt_login_failure_with_retry(self):
+        """
+        When we see an exception on the login, we expect the error to be raised after 3 tries
+        """
+        mocked_service_caller = Mock()
+        mocked_service_caller._make_request = Mock(side_effect=Exception("this is an example auth exception"))
+        salesforce_object = Salesforce(default_start_date="2021-07-15T13:25:54Z")
+        with self.assertRaisesRegexp(Exception, "this is an example auth exception") as e:
+            salesforce_object.attempt_login()
+        self.assertEqual(3, mocked_service_caller._make_request.call_count)
+
+
+"""
+Traceback (most recent call last):
+  File "/opt/code/tap-salesforce/tests/unittests/test_auth_failure.py", line 13, in test_attempt_login_failure_with_retry
+    Salesforce.attempt_login()
+AssertionError: "this is an example auth exception" does not match "attempt_login() missing 1 required positional argument: 'self'"
+"""


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-9784

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
   - wrote unit test, got it to pass
 
# Risks
- the number of retries we use might be too low and cause taps to fail prematurely, that's easy enough to change though

# Rollback steps
 - revert this branch
