### PR TITLE
made timer thread a daemon thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.38
+  * Makes timer thread a daemon thread so that when main thread exits it's ensured that the process exits [#112](https://github.com/singer-io/tap-salesforce/pull/112)
+
 ## 1.4.37
   * Remove support for FieldHistoryArchive because we don't query for it properly [#101](https://github.com/singer-io/tap-salesforce/pull/101)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-salesforce',
-      version='1.4.37',
+      version='1.4.38',
       description='Singer.io tap for extracting data from the Salesforce API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -325,6 +325,7 @@ class Salesforce():
         finally:
             LOGGER.info("Starting new login timer")
             self.login_timer = threading.Timer(REFRESH_TOKEN_EXPIRATION_PERIOD, self.login)
+            self.login_timer.daemon = True # The timer should be a daemon thread so the process exits.
             self.login_timer.start()
 
     def describe(self, sobject=None):


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-9784
so the reason these processes were hanging for 24 hours is because in some rare cases the main thread would exit but a new timer thread would begin which would never be canceled and keep spawning a new thread for the rest of the 24 hours.
This pr makes the timer thread a daemon thread, which ensures that when the main thread exits the process will exit.
# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
- low

# Rollback steps
 - revert this branch
