### PR TITLE
Fix login thread

### DIFF
--- a/spikes/test_threads.py
+++ b/spikes/test_threads.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import sys
+import threading
+from time import sleep
+from datetime import datetime
+
+TIMER_LENGTH = 1
+
+def login():
+    print(f"In login, time is {datetime.now()}, threads is {threading.active_count()}")
+    main_thread = threading.main_thread()
+    main_is_alive = main_thread.is_alive()
+    print(f"In login, main thread is alive? {main_is_alive}")
+
+    # if not main_is_alive:
+    #     print(f"In login, the main thread died, so time to go")
+    #     sys.exit(0)
+
+    myTimer = threading.Timer(TIMER_LENGTH, login )
+    myTimer.daemon = True
+    myTimer.start()
+
+def main():
+    print("In Main")
+    login()
+    sleep(5)
+    sys.exit(0)
+
+
+
+
+main()

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -268,7 +268,7 @@ class Salesforce():
 
     # pylint: disable=too-many-arguments
     @backoff.on_exception(backoff.expo,
-                          requests.exceptions.ConnectionError,
+                          (requests.exceptions.ConnectionError, requests.exceptions.Timeout),
                           max_tries=10,
                           factor=2,
                           on_backoff=log_backoff_attempt)

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -275,10 +275,10 @@ class Salesforce():
     def _make_request(self, http_method, url, headers=None, body=None, stream=False, params=None):
         if http_method == "GET":
             LOGGER.info("Making %s request to %s with params: %s", http_method, url, params)
-            resp = self.session.get(url, headers=headers, stream=stream, params=params)
+            resp = self.session.get(url, headers=headers, stream=stream, params=params, timeout=30)
         elif http_method == "POST":
             LOGGER.info("Making %s request to %s with body %s", http_method, url, body)
-            resp = self.session.post(url, headers=headers, data=body)
+            resp = self.session.post(url, headers=headers, data=body, timeout=30)
         else:
             raise TapSalesforceException("Unsupported HTTP method")
 

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -293,10 +293,10 @@ class Salesforce():
             else:
                 raise TapSalesforceException("Unsupported HTTP method")
         except requests.exceptions.ConnectionError as connection_err:
-            LOGGER.error(f'Took longer than {request_timeout} seconds to connect to the server')
+            LOGGER.error('Took longer than %s seconds to connect to the server', request_timeout)
             raise connection_err
         except requests.exceptions.Timeout as timeout_err:
-            LOGGER.error(f'Took longer than {request_timeout} seconds to hear from the server')
+            LOGGER.error('Took longer than %s seconds to hear from the server', request_timeout)
             raise timeout_err
 
 

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -273,14 +273,33 @@ class Salesforce():
                           factor=2,
                           on_backoff=log_backoff_attempt)
     def _make_request(self, http_method, url, headers=None, body=None, stream=False, params=None):
-        if http_method == "GET":
-            LOGGER.info("Making %s request to %s with params: %s", http_method, url, params)
-            resp = self.session.get(url, headers=headers, stream=stream, params=params, timeout=30)
-        elif http_method == "POST":
-            LOGGER.info("Making %s request to %s with body %s", http_method, url, body)
-            resp = self.session.post(url, headers=headers, data=body, timeout=30)
-        else:
-            raise TapSalesforceException("Unsupported HTTP method")
+        # (30 seconds connect timeout, 30 seconds read timeout)
+        # 30 is shorthand for (30, 30)
+        request_timeout = 30
+        try:
+            if http_method == "GET":
+                LOGGER.info("Making %s request to %s with params: %s", http_method, url, params)
+                resp = self.session.get(url,
+                                        headers=headers,
+                                        stream=stream,
+                                        params=params,
+                                        timeout=request_timeout,)
+            elif http_method == "POST":
+                LOGGER.info("Making %s request to %s with body %s", http_method, url, body)
+                resp = self.session.post(url,
+                                         headers=headers,
+                                         data=body,
+                                         timeout=request_timeout,)
+            else:
+                raise TapSalesforceException("Unsupported HTTP method")
+        except requests.exceptions.ConnectionError as connection_err:
+            LOGGER.error(f'Took longer than {request_timeout} seconds to connect to the server')
+            raise connection_err
+        except requests.exceptions.Timeout as timeout_err:
+            LOGGER.error(f'Took longer than {request_timeout} seconds to hear from the server')
+            raise timeout_err
+
+
 
         try:
             resp.raise_for_status()


### PR DESCRIPTION
# Description of change
This PR
* Adds a spike to help understand how daemon threads should work
* Adds a timeout to all requests made by the tap
* Adds logging for the type of timeout that occurs

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
     - I made requests to trigger a `ConnectTimeout` and `ReadTimeout` in order to know what errors to catch
 
# Risks
- Low

# Rollback steps
 - revert this branch
