### PR TITLE
add streams to FORCED_FULL_TABLE list

### DIFF
--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -28,8 +28,13 @@ CONFIG = {
 }
 
 FORCED_FULL_TABLE = {
-    'BackgroundOperationResult', # Does not support ordering by CreatedDate
-    'LoginEvent', # Does not support ordering by CreatedDate
+    # Does not support ordering by CreatedDate
+    'BackgroundOperationResult',
+    'LoginEvent',
+    'LightningUriEvent',
+    'UriEvent',
+    'LogoutEvent',
+    'ReportEvent',
 }
 
 def get_replication_key(sobject_name, fields):


### PR DESCRIPTION
Some streams a user selected from salesforce v52 were failing on incremental replication with: 

> InvalidBatch : Failed to process query: MALFORMED_QUERY:  2021-01-01T00:00:00Z  ORDER BY CreatedDate ASC                                ^ ERROR at Row:1:Column:509 field 'CreatedDate' can not be sorted in a query call

The user resolved the error by switching the streams to full table

# Description of change
(write a short description here or paste a link to JIRA)

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
