### PR TITLE
move runtime and notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,52 +68,70 @@ jobs:
 
 workflows:
   version: 2
-  commit:
+  commit: &commit_jobs
     jobs:
       - ensure_env:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user            
       - run_pylint:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           requires:
             - ensure_env
       - run_integration_tests:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           name: "test_salesforce_activate_version_messages.py"
           test_name: "test_salesforce_activate_version_messages.py"
           requires:
             - ensure_env
       - run_integration_tests:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           name: "test_salesforce_automatic_fields.py"
           test_name: "test_salesforce_automatic_fields.py"
           requires:
             - ensure_env
       - run_integration_tests:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           name: "test_salesforce_bookmarks.py"
           test_name: "test_salesforce_bookmarks.py"
           requires:
             - ensure_env
       - run_integration_tests:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           name: "test_salesforce_discovery.py"
           test_name: "test_salesforce_discovery.py"
           requires:
             - ensure_env
       - run_integration_tests:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           name: "test_salesforce_start_date.py"
           test_name: "test_salesforce_start_date.py"
           requires:
             - ensure_env
       - run_integration_tests:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           name: "test_salesforce_sync_canary.py"
           test_name: "test_salesforce_sync_canary.py"
           requires:
             - ensure_env
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
           requires:
             - run_pylint
             - test_salesforce_activate_version_messages.py
@@ -123,63 +141,11 @@ workflows:
             - test_salesforce_start_date.py
             - test_salesforce_sync_canary.py
   build_daily:
+    <<: *commit_jobs
     triggers:
       - schedule:
-          cron: "0 6 * * *"
+          cron: "0 1 * * *"
           filters:
             branches:
               only:
                 - master
-    jobs:
-      - ensure_env:
-          context: circleci-user
-      - run_pylint:
-          context: circleci-user
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_salesforce_activate_version_messages.py"
-          test_name: "test_salesforce_activate_version_messages.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_salesforce_automatic_fields.py"
-          test_name: "test_salesforce_automatic_fields.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_salesforce_bookmarks.py"
-          test_name: "test_salesforce_bookmarks.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_salesforce_discovery.py"
-          test_name: "test_salesforce_discovery.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_salesforce_start_date.py"
-          test_name: "test_salesforce_start_date.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_salesforce_sync_canary.py"
-          test_name: "test_salesforce_sync_canary.py"
-          requires:
-            - ensure_env
-      - build:
-          context: circleci-user
-          requires:
-            - run_pylint
-            - test_salesforce_activate_version_messages.py
-            - test_salesforce_automatic_fields.py
-            - test_salesforce_bookmarks.py
-            - test_salesforce_discovery.py
-            - test_salesforce_start_date.py
-            - test_salesforce_sync_canary.py


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-16944
Move build time to avoid conflicts with contractors and internal teams.
6:00am UTC -> 1:00 UTC (8:00pm EST, 6:30am IST)

Move slack notifications to new channel.


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
