### PR TITLE
Qa/multi api pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,8 @@ jobs:
             echo "pylint will skip the following: $PYLINT_DISABLE_LIST"
             pylint tap_salesforce -d "$PYLINT_DISABLE_LIST,stop-iteration-return"
   run_integration_tests:
-    parameters:
-      test_name:
-        type: string
     executor: docker-executor
+    parallelism: 7
     steps:
       - checkout
       - attach_workspace:
@@ -61,8 +59,13 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-
-            run-test --tap=tap-salesforce tests/<< parameters.test_name >>
+            circleci tests glob "tests/*.py" | circleci tests split > ./tests-to-run
+            if [ -s ./tests-to-run ]; then
+              for test_file in $(cat ./tests-to-run)
+              do
+                run-test --tap=${CIRCLE_PROJECT_REPONAME} $test_file
+              done
+            fi
       - slack/notify-on-failure:
           only_for_branches: master
 
@@ -73,7 +76,7 @@ workflows:
       - ensure_env:
           context:
             - circleci-user
-            - tier-1-tap-user            
+            - tier-1-tap-user
       - run_pylint:
           context:
             - circleci-user
@@ -84,48 +87,6 @@ workflows:
           context:
             - circleci-user
             - tier-1-tap-user
-          name: "test_salesforce_activate_version_messages.py"
-          test_name: "test_salesforce_activate_version_messages.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          name: "test_salesforce_automatic_fields.py"
-          test_name: "test_salesforce_automatic_fields.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          name: "test_salesforce_bookmarks.py"
-          test_name: "test_salesforce_bookmarks.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          name: "test_salesforce_discovery.py"
-          test_name: "test_salesforce_discovery.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          name: "test_salesforce_start_date.py"
-          test_name: "test_salesforce_start_date.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          name: "test_salesforce_sync_canary.py"
-          test_name: "test_salesforce_sync_canary.py"
           requires:
             - ensure_env
       - build:
@@ -134,12 +95,7 @@ workflows:
             - tier-1-tap-user
           requires:
             - run_pylint
-            - test_salesforce_activate_version_messages.py
-            - test_salesforce_automatic_fields.py
-            - test_salesforce_bookmarks.py
-            - test_salesforce_discovery.py
-            - test_salesforce_start_date.py
-            - test_salesforce_sync_canary.py
+            - run_integration_tests
   build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
             pylint tap_salesforce -d "$PYLINT_DISABLE_LIST,stop-iteration-return"
   run_integration_tests:
     executor: docker-executor
-    parallelism: 7
+    parallelism: 8
     steps:
       - checkout
       - attach_workspace:

--- a/tests/base.py
+++ b/tests/base.py
@@ -38,6 +38,7 @@ class SalesforceBaseTest(unittest.TestCase):
     BOOKMARK_COMPARISON_FORMAT = "%Y-%m-%dT00:00:00.000000Z"
     LOGGER = singer.get_logger()
     start_date = ""
+    salesforce_api = ""
 
     @staticmethod
     def tap_name():
@@ -56,7 +57,7 @@ class SalesforceBaseTest(unittest.TestCase):
             'instance_url': 'https://singer2-dev-ed.my.salesforce.com',
             'select_fields_by_default': 'true',
             'quota_percent_total': '80',
-            'api_type': 'BULK',
+            'api_type': self.salesforce_api,
             'is_sandbox': 'false'
         }
 
@@ -762,11 +763,42 @@ class SalesforceBaseTest(unittest.TestCase):
             'WorkTypeGroupShare': incremental_last_modified,  # new
             'WorkTypeHistory': incremental_created_date,  # new
             'WorkTypeShare': incremental_last_modified,  # new
+            'RecentlyViewed': default_full,  # new TODO verify this is not a bug
+            'TaskPriority': default,  # new TODO
+            'DeclinedEventRelation': default,  # new TODO
+            'AcceptedEventRelation': default,  # new TODO
+            'OrderStatus': default,  # new TODO
+            'SolutionStatus': default,  # new TODO
+            'CaseStatus': default,  # new TODO
+            'TaskStatus': default,  # new TODO
+            'PartnerRole': default,  # new TODO
+            'ContractStatus': default,  # new TODO
+            'UndecidedEventRelation': default,  # new TODO
+        }
+
+    def rest_only_streams(self):
+        """A group of streams that is only discovered when the REST API is in use."""
+        return {
+            'CaseStatus',
+            'DeclinedEventRelation',
+            'RecentlyViewed',
+            'SolutionStatus',
+            'TaskStatus',
+            'OrderStatus',
+            'AcceptedEventRelation',
+            'ContractStatus',
+            'PartnerRole',
+            'TaskPriority',
+            'UndecidedEventRelation',
         }
 
     def expected_streams(self):
         """A set of expected stream names"""
-        return set(self.expected_metadata().keys())
+        streams = set(self.expected_metadata().keys())
+
+        if self.salesforce_api == 'BULK':
+            return streams.difference(self.rest_only_streams())
+        return streams
 
     def child_streams(self):
         """

--- a/tests/test_salesforce_activate_version_messages.py
+++ b/tests/test_salesforce_activate_version_messages.py
@@ -33,6 +33,7 @@ class SalesforceActivateVersionMessages(SalesforceBaseTest):
         4. start a new full table
            - should emit activate version message at end with new version
         """
+        self.salesforce_api = 'BULK'
 
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_salesforce_automatic_fields.py
+++ b/tests/test_salesforce_automatic_fields.py
@@ -12,19 +12,7 @@ from base import SalesforceBaseTest
 class SalesforceAutomaticFields(SalesforceBaseTest):
     """Test that with no fields selected for a stream automatic fields are still replicated"""
 
-    @staticmethod
-    def name():
-        return "tap_tester_salesforce_automatic_fields"
-
-    @staticmethod
-    def get_properties():  # pylint: disable=arguments-differ
-        return {
-            'start_date' : (datetime.now() + timedelta(days=-1)).strftime("%Y-%m-%dT00:00:00Z"),
-            'instance_url': 'https://singer2-dev-ed.my.salesforce.com',
-            'select_fields_by_default': 'true',
-            'api_type': 'BULK',
-            'is_sandbox': 'false'
-        }
+    start_date =  (datetime.now() + timedelta(days=-1)).strftime("%Y-%m-%dT00:00:00Z")
 
     @staticmethod
     def expected_sync_streams():
@@ -36,7 +24,7 @@ class SalesforceAutomaticFields(SalesforceBaseTest):
             'User',
         }
 
-    def test_run(self):
+    def automatic_fields_test(self):
         """
         Verify that for each stream you can get multiple pages of data
         when no fields are selected and only the automatic fields are replicated.
@@ -50,7 +38,7 @@ class SalesforceAutomaticFields(SalesforceBaseTest):
         expected_streams = self.expected_sync_streams()
 
         # instantiate connection
-        conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection(self, original_properties=False)
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)
@@ -87,3 +75,29 @@ class SalesforceAutomaticFields(SalesforceBaseTest):
                 # Verify that only the automatic fields are sent to the target
                 for actual_keys in record_messages_keys:
                     self.assertSetEqual(expected_keys, actual_keys)
+
+
+class SalesforceAutomaticFieldsBulk(SalesforceAutomaticFields):
+    """Test that with no fields selected for a stream automatic fields are still replicated"""
+
+    salesforce_api = 'BULK'
+
+    @staticmethod
+    def name():
+        return "tt_salesforce_auto_bulk"
+
+    def test_run(self):
+        self.automatic_fields_test()
+
+
+class SalesforceAutomaticFieldsRest(SalesforceAutomaticFields):
+    """Test that with no fields selected for a stream automatic fields are still replicated"""
+
+    salesforce_api = 'REST'
+
+    @staticmethod
+    def name():
+        return "tt_salesforce_auto_rest"
+
+    def test_run(self):
+        self.automatic_fields_test()

--- a/tests/test_salesforce_automatic_fields_bulk.py
+++ b/tests/test_salesforce_automatic_fields_bulk.py
@@ -1,0 +1,22 @@
+"""
+Test that with no fields selected for a stream automatic fields are still replicated
+"""
+import unittest
+from datetime import datetime, timedelta
+
+from tap_tester import runner, connections
+
+from test_salesforce_automatic_fields_rest import SalesforceAutomaticFields
+
+
+class SalesforceAutomaticFieldsBulk(SalesforceAutomaticFields):
+    """Test that with no fields selected for a stream automatic fields are still replicated"""
+
+    salesforce_api = 'BULK'
+
+    @staticmethod
+    def name():
+        return "tt_salesforce_auto_bulk"
+
+    def test_run(self):
+        self.automatic_fields_test()

--- a/tests/test_salesforce_automatic_fields_rest.py
+++ b/tests/test_salesforce_automatic_fields_rest.py
@@ -77,19 +77,6 @@ class SalesforceAutomaticFields(SalesforceBaseTest):
                     self.assertSetEqual(expected_keys, actual_keys)
 
 
-class SalesforceAutomaticFieldsBulk(SalesforceAutomaticFields):
-    """Test that with no fields selected for a stream automatic fields are still replicated"""
-
-    salesforce_api = 'BULK'
-
-    @staticmethod
-    def name():
-        return "tt_salesforce_auto_bulk"
-
-    def test_run(self):
-        self.automatic_fields_test()
-
-
 class SalesforceAutomaticFieldsRest(SalesforceAutomaticFields):
     """Test that with no fields selected for a stream automatic fields are still replicated"""
 

--- a/tests/test_salesforce_bookmarks.py
+++ b/tests/test_salesforce_bookmarks.py
@@ -62,6 +62,8 @@ class SalesforceBookmarks(SalesforceBaseTest):
         return stream_to_calculated_state
 
     def test_run(self):
+        self.salesforce_api = 'BULK'
+
         replication_keys = self.expected_replication_keys()
 
         # SYNC 1

--- a/tests/test_salesforce_discovery_bulk.py
+++ b/tests/test_salesforce_discovery_bulk.py
@@ -1,0 +1,17 @@
+"""Test tap discovery mode and metadata/annotated-schema."""
+import unittest
+from tap_tester import menagerie, connections
+
+from test_salesforce_discovery_rest import DiscoveryTest
+
+
+class DiscoveryTestBulk(DiscoveryTest):
+    """Test tap discovery mode with the BULK API selected"""
+
+    @staticmethod
+    def name():
+        return "tt_salesforce_disco_bulk"
+
+    def test_discovery(self):
+        self.salesforce_api = 'BULK'
+        self.discovery_test()

--- a/tests/test_salesforce_start_date.py
+++ b/tests/test_salesforce_start_date.py
@@ -25,6 +25,7 @@ class SalesforceStartDateTest(SalesforceBaseTest):
 
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
+        self.salesforce_api = 'BULK'
 
         self.assertTrue(self.expected_sync_streams().issubset(self.expected_streams()))
 


### PR DESCRIPTION
# Description of change
POC running basic tap-tester against both APIs.
Ported discovery and automatic fields tests to two separate files that each run against a different SF API.
# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
