### PR TITLE
TDL-7301: Handle multiline `CRITICAL` error messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,12 @@ workflows:
             - tier-1-tap-user
           requires:
             - ensure_env
+      - run_unit_tests:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          requires:
+            - ensure_env
       - run_integration_tests:
           context:
             - circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-salesforce/bin/activate
             pip install nose coverage
-            nosetests --with-coverage --cover-erase --cover-package=tap_facebook --cover-html-dir=htmlcov tests/unittests
+            nosetests --with-coverage --cover-erase --cover-package=tap_salesforce --cover-html-dir=htmlcov tests/unittests
             coverage html
       - store_test_results:
           path: test_output/report.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,23 @@ jobs:
             pip install pylint
             echo "pylint will skip the following: $PYLINT_DISABLE_LIST"
             pylint tap_salesforce -d "$PYLINT_DISABLE_LIST,stop-iteration-return"
+  run_unit_tests:
+    executor: docker-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
+      - run:
+          name: 'Run Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-salesforce/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_facebook --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
   run_integration_tests:
     executor: docker-executor
     parallelism: 8

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -417,5 +417,6 @@ def main():
         LOGGER.critical(e)
         sys.exit(1)
     except Exception as e:
-        LOGGER.critical(e)
+        for error_line in str(e).splitlines():
+            LOGGER.critical(error_line)
         raise e

--- a/tests/unittests/test_multiline_critical_error_message.py
+++ b/tests/unittests/test_multiline_critical_error_message.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest import mock
+from tap_salesforce import main
+
+# mock "main_impl" and raise multiline error
+def raise_error():
+    raise Exception("""Error syncing Transaction__c: 400 Client Error: Bad Request for url: https://test.my.salesforce.com/services/async/41.0/job/7502K00000IcACtQAN/batch/test123j/result/test123b Response: <?xml version="1.0" encoding="UTF-8"?><error
+       xmlns="http://www.test-force.com/20091/01/asyncapi1/dataload1">
+     <exceptionCode>InvalidSessionId</exceptionCode>
+     <exceptionMessage>Invalid session id</exceptionMessage>
+    </error>""")
+
+class TestMultiLineCriticalErrorMessage(unittest.TestCase):
+    """
+        Test case to verify every line in the multiline error contains 'CRITICAL'
+    """
+
+    @mock.patch("tap_salesforce.LOGGER.critical")
+    @mock.patch("tap_salesforce.main_impl")
+    def test_multiline_critical_error_message(self, mocked_main_impl, mocked_logger_critical):
+        # mock "main_impl" and raise multiline error
+        mocked_main_impl.side_effect = raise_error
+
+        # verify "Exception" is raise on function call
+        with self.assertRaises(Exception):
+            main()
+
+        # verify "LOGGER.critical" is called 5 times, as the error raised contains 5 lines
+        self.assertEqual(mocked_logger_critical.call_count, 5)


### PR DESCRIPTION
# Description of change
TDL-7301: Handle multiline `CRITICAL` error messages
- Updated code to add `CRITICAL` for multiline error messages

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
