### PR TITLE
TDL-16006: Fix interruptible full table bookmarking strategy for bulk API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,23 @@ jobs:
             pip install pylint
             echo "pylint will skip the following: $PYLINT_DISABLE_LIST"
             pylint tap_salesforce -d "$PYLINT_DISABLE_LIST,stop-iteration-return"
+  run_unit_tests:
+    executor: docker-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
+      - run:
+          name: 'Run Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-salesforce/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_salesforce --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
   run_integration_tests:
     executor: docker-executor
     parallelism: 8
@@ -78,6 +95,12 @@ workflows:
             - circleci-user
             - tier-1-tap-user
       - run_pylint:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          requires:
+            - ensure_env
+      - run_unit_tests:
           context:
             - circleci-user
             - tier-1-tap-user

--- a/tap_salesforce/sync.py
+++ b/tap_salesforce/sync.py
@@ -173,8 +173,8 @@ def sync_records(sf, catalog_entry, state, counter):
         state = singer.write_bookmark(
             state, catalog_entry['tap_stream_id'], 'version', None)
 
-    # If pk_chunking is set, only write a bookmark at the end
-    if sf.pk_chunking:
+    # If pk_chunking is set, and selected streams has replication key then only write a bookmark at the end
+    if sf.pk_chunking and replication_key:
         # Write a bookmark with the highest value we've seen
         state = singer.write_bookmark(
             state,

--- a/tests/unittests/test_salesforce_null_bookmark.py
+++ b/tests/unittests/test_salesforce_null_bookmark.py
@@ -2,7 +2,6 @@ import logging
 from typing import Counter
 import unittest
 from unittest import mock
-# from tap_salesforce import main
 import tap_salesforce
 from tap_salesforce import Salesforce, metrics
 from tap_salesforce.sync import sync_records
@@ -14,7 +13,8 @@ class TestNullBookmarkTesting(unittest.TestCase):
     @mock.patch('tap_salesforce.salesforce.Salesforce.query', side_effect=lambda test1, test2: [])
     def test_not_null_bookmark_for_incremental_stream(self, mocked_query):
         """
-        To ensure that after resolving writebook mark logic not get "Null" key in state
+        To ensure that after resolving write bookmark logic not get "Null" as replication key in state file, 
+        When we have selected incremental stream as Full table stream
 
         """
         sf = Salesforce(

--- a/tests/unittests/test_salesforce_null_bookmark.py
+++ b/tests/unittests/test_salesforce_null_bookmark.py
@@ -1,5 +1,3 @@
-import logging
-from typing import Counter
 import unittest
 from unittest import mock
 import tap_salesforce

--- a/tests/unittests/test_salesforce_null_bookmark.py
+++ b/tests/unittests/test_salesforce_null_bookmark.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Counter
+import unittest
+from unittest import mock
+# from tap_salesforce import main
+import tap_salesforce
+from tap_salesforce import Salesforce, metrics
+from tap_salesforce.sync import sync_records
+import json
+
+
+
+class TestNullBookmarkTesting(unittest.TestCase):
+    @mock.patch('tap_salesforce.salesforce.Salesforce.query', side_effect=lambda test1, test2: [])
+    def test_not_null_bookmark_for_incremental_stream(self, mocked_query):
+        """
+        To ensure that after resolving writebook mark logic not get "Null" key in state
+
+        """
+        sf = Salesforce(
+            refresh_token="test",
+            sf_client_id="test",
+            sf_client_secret="test",
+            quota_percent_total=None,
+            quota_percent_per_run=None,
+            is_sandbox=None,
+            select_fields_by_default= False,
+            default_start_date='2019-02-04T12:15:00Z',
+            api_type="BULK")
+        
+        sf.pk_chunking = True
+        sf.instance_url = "https://cds-e-dev-ed.my.salesforce.com"
+        catalog_entry = {"stream": "OpportunityLineItem", "schema": {}, "metadata":[], "tap_stream_id": "OpportunityLineItem"}
+        state = {}
+        counter = metrics.record_counter('OpportunityLineItem')
+        sync_records(sf, catalog_entry, state, counter)
+        # write state function convert python dictionary to json string
+        state = json.dumps(state)
+        self.assertEqual(state, '{"bookmarks": {"OpportunityLineItem": {"version": null}}}', "Not get expected state value")

--- a/tests/unittests/test_salesforce_null_bookmark.py
+++ b/tests/unittests/test_salesforce_null_bookmark.py
@@ -1,11 +1,8 @@
 import unittest
 from unittest import mock
-import tap_salesforce
 from tap_salesforce import Salesforce, metrics
 from tap_salesforce.sync import sync_records
 import json
-
-
 
 class TestNullBookmarkTesting(unittest.TestCase):
     @mock.patch('tap_salesforce.salesforce.Salesforce.query', side_effect=lambda test1, test2: [])
@@ -15,19 +12,9 @@ class TestNullBookmarkTesting(unittest.TestCase):
         When we have selected incremental stream as Full table stream
 
         """
-        sf = Salesforce(
-            refresh_token="test",
-            sf_client_id="test",
-            sf_client_secret="test",
-            quota_percent_total=None,
-            quota_percent_per_run=None,
-            is_sandbox=None,
-            select_fields_by_default= False,
-            default_start_date='2019-02-04T12:15:00Z',
-            api_type="BULK")
-        
+        sf = Salesforce(default_start_date='2019-02-04T12:15:00Z', api_type="BULK")
+
         sf.pk_chunking = True
-        sf.instance_url = "https://cds-e-dev-ed.my.salesforce.com"
         catalog_entry = {"stream": "OpportunityLineItem", "schema": {}, "metadata":[], "tap_stream_id": "OpportunityLineItem"}
         state = {}
         counter = metrics.record_counter('OpportunityLineItem')


### PR DESCRIPTION
# Description of change
 - Write unit test reproduce scenario where Full Table write bookmark with null key
 - Resolved Full Table bookmarking with null key state
 
# Risks

# Rollback steps
 - revert this branch
