### PR TITLE
use tap-tester logger in place of singer logger in tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -7,8 +7,7 @@ import os
 from datetime import timedelta
 from datetime import datetime as dt
 
-import singer
-from tap_tester import connections, menagerie, runner
+from tap_tester import connections, menagerie, runner, logger
 
 
 class SalesforceBaseTest(unittest.TestCase):
@@ -36,7 +35,7 @@ class SalesforceBaseTest(unittest.TestCase):
     FULL_TABLE = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
     BOOKMARK_COMPARISON_FORMAT = "%Y-%m-%dT00:00:00.000000Z"
-    LOGGER = singer.get_logger()
+    LOGGER = logger.LOGGER
     start_date = ""
     salesforce_api = ""
 


### PR DESCRIPTION
# Description of change
Use tap-tester logger in place of singer logger in tests
# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
