### PR TITLE
TDL-23556 Update PKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0
+  * Fix the LightningUriEvent stream primary key [#163](https://github.com/singer-io/tap-salesforce/pull/163)
+
 ## 1.5.6
   * Dependabot update [#158](https://github.com/singer-io/tap-salesforce/pull/158)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-salesforce',
-      version='1.5.6',
+      version='2.0.0',
       description='Singer.io tap for extracting data from the Salesforce API',
       author='Stitch',
       url='https://singer.io',
@@ -11,7 +11,7 @@ setup(name='tap-salesforce',
       py_modules=['tap_salesforce'],
       install_requires=[
           'requests==2.31.0',
-          'singer-python==5.10.0',
+          'singer-python==5.13.0',
           'xmltodict==0.11.0'
       ],
       entry_points='''

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -222,7 +222,7 @@ def do_discover(sf):
         if not found_expected_pk_field:
             LOGGER.info(
                 "Skipping Salesforce Object %s, as it has no %s field",
-                sobject_name, field_name)
+                sobject_name, expected_pk_field)
             continue
 
         # Any property added to unsupported_fields has metadata generated and

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -159,7 +159,7 @@ def do_discover(sf):
         properties = {}
         mdata = metadata.new()
 
-        found_id_field = False
+        found_expected_pk_field = False
 
         expected_pk_field = PK_OVERRIDES.get(sobject_name, "Id")
 
@@ -168,7 +168,7 @@ def do_discover(sf):
             field_name = f['name']
 
             if field_name == expected_pk_field:
-                found_id_field = True
+                found_expected_pk_field = True
 
             property_schema, mdata = create_property_schema(f, mdata, expected_pk_field)
 
@@ -219,7 +219,7 @@ def do_discover(sf):
                         ', '.join(sorted([k for k, _ in filtered_unsupported_fields])))
 
         # Salesforce Objects are skipped when they do not have an Id field
-        if not found_id_field:
+        if not found_expected_pk_field:
             LOGGER.info(
                 "Skipping Salesforce Object %s, as it has no Id field",
                 sobject_name)

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -218,11 +218,11 @@ def do_discover(sf):
                         sobject_name,
                         ', '.join(sorted([k for k, _ in filtered_unsupported_fields])))
 
-        # Salesforce Objects are skipped when they do not have an Id field
+        # Salesforce Objects are skipped when they do not have an expected pk field
         if not found_expected_pk_field:
             LOGGER.info(
-                "Skipping Salesforce Object %s, as it has no Id field",
-                sobject_name)
+                "Skipping Salesforce Object %s, as it has no %s field",
+                sobject_name, field_name)
             continue
 
         # Any property added to unsupported_fields has metadata generated and

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -94,10 +94,10 @@ def build_state(raw_state, catalog):
     return state
 
 # pylint: disable=undefined-variable
-def create_property_schema(field, mdata):
+def create_property_schema(field, mdata, expected_pk_field):
     field_name = field['name']
 
-    if field_name == "Id":
+    if field_name == expected_pk_field:
         mdata = metadata.write(
             mdata, ('properties', field_name), 'inclusion', 'automatic')
     else:
@@ -170,8 +170,7 @@ def do_discover(sf):
             if field_name == expected_pk_field:
                 found_id_field = True
 
-            property_schema, mdata = create_property_schema(
-                f, mdata)
+            property_schema, mdata = create_property_schema(f, mdata, expected_pk_field)
 
             # Compound Address fields and geolocations cannot be queried by the Bulk API
             if f['type'] in ("address", "location") and sf.api_type == tap_salesforce.salesforce.BULK_API_TYPE:

--- a/tests/base.py
+++ b/tests/base.py
@@ -98,6 +98,11 @@ class SalesforceBaseTest(BaseCase):
             self.REPLICATION_KEYS: {'LastModifiedDate'},
             self.REPLICATION_METHOD: self.INCREMENTAL,
         }
+
+        lightning_uri_event_full = {
+            self.PRIMARY_KEYS: {"EventIdentifier"},
+            self.REPLICATION_METHOD: self.FULL_TABLE,
+        }
         return {
             'AIApplication': default,  # removed # 6/13/2022 added back 7/10/2022
             'AIApplicationConfig': default,  # removed # 6/13/2022 added back 7/10/2022
@@ -462,7 +467,7 @@ class SalesforceBaseTest(BaseCase):
             'LightningExperienceTheme': default,
             'LightningOnboardingConfig': default,
             'LightningToggleMetrics': default,  # new
-            'LightningUriEvent': default_full,  # new
+            'LightningUriEvent': lightning_uri_event_full,  # new
             'LightningUsageByAppTypeMetrics': default,  # new
             'LightningUsageByBrowserMetrics': default,  # new
             'LightningUsageByFlexiPageMetrics': default,  # new


### PR DESCRIPTION
# Description of change
This PR fixes the primary key for the `LightningUriEvent` Stream to make what Salesforce Docs says is the unique identifier of the event.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 
# Risks
- PK changes require a major version bump

# Rollback steps
 - revert this branch
