### PR TITLE
Qa/custom objects tdl 17114 3

### DIFF
--- a/tests/test_table_reset.py
+++ b/tests/test_table_reset.py
@@ -18,6 +18,6 @@ class SFTableResetTest(TableResetTest, SFBaseTest):
     def reset_stream(self):
         return ('User')
 
-    def manipulate_state(self, first_sync_state):
+    def manipulate_state(self, current_state):
         # no state manipulation needed for this tap
-        return first_sync_state
+        return current_state

--- a/tests/test_table_reset.py
+++ b/tests/test_table_reset.py
@@ -17,3 +17,7 @@ class SFTableResetTest(TableResetTest, SFBaseTest):
     @property
     def reset_stream(self):
         return ('User')
+
+    def manipulate_state(self, first_sync_state):
+        # no state manipulation needed for this tap
+        return first_sync_state


### PR DESCRIPTION
# Description of change
Include additional_md to add replication key to fix query so it includes start_date.  Update reset test as it no longer needs to do anything to change the state.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
