### PR TITLE
SAC-30291: Bump singer-python to 6.8.0 and update tests to use `versions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.7.0
-  - Bump singer-python to `6.8.0` and update tests to use renamed state key `versions` [#208](https://github.com/singer-io/tap-salesforce/pull/208)
+  - Bump singer-python to `6.8.0` and update tests to use renamed state key `versions` [#210](https://github.com/singer-io/tap-salesforce/pull/210)
 
 ## 2.6.1
   - Bug fix for empty state key error in build_state function [#209](https://github.com/singer-io/tap-salesforce/pull/209)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.7.0
+  - Bump singer-python to `6.8.0` and update tests to use renamed state key `versions` [#208](https://github.com/singer-io/tap-salesforce/pull/208)
+
 ## 2.6.1
   - Bug fix for empty state key error in build_state function [#209](https://github.com/singer-io/tap-salesforce/pull/209)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-salesforce',
-      version='2.6.1',
+      version='2.7.0',
       description='Singer.io tap for extracting data from the Salesforce API',
       author='Stitch',
       url='https://singer.io',
@@ -11,7 +11,7 @@ setup(name='tap-salesforce',
       py_modules=['tap_salesforce'],
       install_requires=[
           'requests==2.32.5',
-          'singer-python==6.7.0',
+          'singer-python==6.8.0',
           'xmltodict==1.0.2',
       ],
       entry_points='''

--- a/tests/test_salesforce_full_table_replication.py
+++ b/tests/test_salesforce_full_table_replication.py
@@ -75,9 +75,9 @@ class SalesforceFullReplicationTest(SalesforceBaseTest):
 
                 # Verify if the bookmarks for first and second sync for full table are None
                 self.assertIsNone(first_sync_state['bookmarks'].get(stream).get('version'))
-                self.assertIsNone(first_sync_state['activate_versions'].get(stream))
+                self.assertIsNone(first_sync_state['versions'].get(stream))
                 self.assertIsNone(second_sync_state['bookmarks'].get(stream).get('version'))
-                self.assertIsNone(second_sync_state['activate_versions'].get(stream))
+                self.assertIsNone(second_sync_state['versions'].get(stream))
 
                 # verify all data from 1st sync included in 2nd sync
                 first_data = [record["data"] for record

--- a/tests/unittests/test_salesforce_null_bookmark.py
+++ b/tests/unittests/test_salesforce_null_bookmark.py
@@ -8,7 +8,7 @@ class TestNullBookmarkTesting(unittest.TestCase):
     @mock.patch('tap_salesforce.salesforce.Salesforce.query', side_effect=lambda test1, test2: [])
     def test_not_null_bookmark_for_incremental_stream(self, mocked_query):
         """
-        To ensure that after resolving write bookmark logic not get "Null" as replication key in state file, 
+        To ensure that after resolving write bookmark logic not get "Null" as replication key in state file,
         When we have selected incremental stream as Full table stream
 
         """
@@ -20,5 +20,5 @@ class TestNullBookmarkTesting(unittest.TestCase):
         counter = metrics.record_counter('OpportunityLineItem')
         sync_records(sf, catalog_entry, state, counter)
         self.assertEqual(state, {'bookmarks': {'OpportunityLineItem': {}},
-                                 'activate_versions': {}},
+                                 'versions': {}},
                          "Not get expected state value")


### PR DESCRIPTION
# Description of change
V 2.7.0
- Bump singer-python to 6.8.0
- Update tests to use the correct state key name to align with singer-python 6.8.0.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
