### PR TITLE
Support OAuth refresh token rotation for Salesforce connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.7.1
-  - Bump singer-python to `6.8.0` and update tests to use renamed state key `versions` [#210](https://github.com/singer-io/tap-salesforce/pull/210)
+  - Support OAuth refresh token rotation [#216](https://github.com/singer-io/tap-salesforce/pull/216)
 
 ## 2.7.0
   - Bump singer-python to `6.8.0` and update tests to use renamed state key `versions` [#210](https://github.com/singer-io/tap-salesforce/pull/210)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.7.1
+## 2.8.0
   - Support OAuth refresh token rotation [#216](https://github.com/singer-io/tap-salesforce/pull/216)
 
 ## 2.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.7.1
+  - Bump singer-python to `6.8.0` and update tests to use renamed state key `versions` [#210](https://github.com/singer-io/tap-salesforce/pull/210)
+
 ## 2.7.0
   - Bump singer-python to `6.8.0` and update tests to use renamed state key `versions` [#210](https://github.com/singer-io/tap-salesforce/pull/210)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-salesforce',
-      version='2.7.1',
+      version='2.8.0',
       description='Singer.io tap for extracting data from the Salesforce API',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-salesforce',
-      version='2.7.0',
+      version='2.7.1',
       description='Singer.io tap for extracting data from the Salesforce API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_salesforce/__init__.py
+++ b/tap_salesforce/__init__.py
@@ -416,7 +416,8 @@ def main_impl():
             select_fields_by_default=CONFIG.get('select_fields_by_default'),
             default_start_date=CONFIG.get('start_date'),
             api_type=CONFIG.get('api_type'),
-            lookback_window=lookback_window)
+            lookback_window=lookback_window,
+            config_path=args.config_path)
         sf.login()
 
         if args.discover:

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import re
 import threading
 import time
@@ -220,10 +221,12 @@ class Salesforce():
                  select_fields_by_default=None,
                  default_start_date=None,
                  api_type=None,
-                 lookback_window=None):
+                 lookback_window=None,
+                 config_path=None):
         self.api_type = api_type.upper() if api_type else None
         self.refresh_token = refresh_token
         self.token = token
+        self.config_path = config_path
         self.sf_client_id = sf_client_id
         self.sf_client_secret = sf_client_secret
         self.session = requests.Session()
@@ -252,6 +255,20 @@ class Salesforce():
 
     def _get_standard_headers(self):
         return {"Authorization": "Bearer {}".format(self.access_token)}
+
+    def _write_config(self):
+        """Persist the rotated refresh token back to the config file."""
+        if not self.config_path:
+            return
+        LOGGER.info("Persisting rotated refresh token to config file.")
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+            config['refresh_token'] = self.refresh_token
+            with open(self.config_path, 'w', encoding='utf-8') as f:
+                json.dump(config, f, indent=2)
+        except Exception as e:  # pylint: disable=broad-except
+            LOGGER.warning("Failed to persist rotated refresh token to config file: %s", e)
 
     # pylint: disable=anomalous-backslash-in-string,line-too-long
     def check_rest_quota_usage(self, headers):
@@ -350,6 +367,13 @@ class Salesforce():
 
             self.access_token = auth['access_token']
             self.instance_url = auth['instance_url']
+            new_refresh_token = auth.get('refresh_token')
+            if new_refresh_token and new_refresh_token != self.refresh_token:
+                LOGGER.info("Refresh token rotation detected. Updating refresh token.")
+                self.refresh_token = new_refresh_token
+                self._write_config()
+            else:
+                LOGGER.info("No refresh token rotation detected.")
         except Exception as e:
             error_message = str(e)
             if resp is None and hasattr(e, 'response') and e.response is not None: #pylint:disable=no-member

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -257,10 +257,9 @@ class Salesforce():
         return {"Authorization": "Bearer {}".format(self.access_token)}
 
     def _write_config(self):
-        """Persist the rotated refresh token back to the config file."""
+        # Persist the rotated refresh token back to the config file.
         if not self.config_path:
             return
-        LOGGER.info("Persisting rotated refresh token to config file.")
         try:
             with open(self.config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
@@ -367,7 +366,7 @@ class Salesforce():
 
             self.access_token = auth['access_token']
             self.instance_url = auth['instance_url']
-            new_refresh_token = auth.get('refresh_token')
+            new_refresh_token = auth['refresh_token']
             if new_refresh_token and new_refresh_token != self.refresh_token:
                 LOGGER.info("Refresh token rotation detected. Updating refresh token.")
                 self.refresh_token = new_refresh_token

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -257,17 +257,13 @@ class Salesforce():
         return {"Authorization": "Bearer {}".format(self.access_token)}
 
     def _write_config(self):
-        # Persist the rotated refresh token back to the config file.
-        if not self.config_path:
-            return
-        try:
-            with open(self.config_path, 'r', encoding='utf-8') as f:
-                config = json.load(f)
-            config['refresh_token'] = self.refresh_token
-            with open(self.config_path, 'w', encoding='utf-8') as f:
-                json.dump(config, f, indent=2)
-        except Exception as e:  # pylint: disable=broad-except
-            LOGGER.warning("Failed to persist rotated refresh token to config file: %s", e)
+        """Save updated config (with new token) back to config file."""
+        with open(self.config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+        config['refresh_token'] = self.refresh_token
+        with open(self.config_path, 'w', encoding='utf-8') as f:
+            json.dump(config, f, indent=2)
+        LOGGER.info("Updated config file with new refresh token.")
 
     # pylint: disable=anomalous-backslash-in-string,line-too-long
     def check_rest_quota_usage(self, headers):
@@ -366,7 +362,7 @@ class Salesforce():
 
             self.access_token = auth['access_token']
             self.instance_url = auth['instance_url']
-            new_refresh_token = auth['refresh_token']
+            new_refresh_token = auth.get('refresh_token')
             if new_refresh_token and new_refresh_token != self.refresh_token:
                 LOGGER.info("Refresh token rotation detected. Updating refresh token.")
                 self.refresh_token = new_refresh_token

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -362,6 +362,8 @@ class Salesforce():
 
             self.access_token = auth['access_token']
             self.instance_url = auth['instance_url']
+            # Salesforce may or may not return a new refresh token. If it does, 
+            # we should update to use the new one.
             new_refresh_token = auth.get('refresh_token')
             if new_refresh_token and new_refresh_token != self.refresh_token:
                 LOGGER.info("Refresh token rotation detected. Updating refresh token.")

--- a/tap_salesforce/salesforce/__init__.py
+++ b/tap_salesforce/salesforce/__init__.py
@@ -362,7 +362,7 @@ class Salesforce():
 
             self.access_token = auth['access_token']
             self.instance_url = auth['instance_url']
-            # Salesforce may or may not return a new refresh token. If it does, 
+            # Salesforce may or may not return a new refresh token. If it does,
             # we should update to use the new one.
             new_refresh_token = auth.get('refresh_token')
             if new_refresh_token and new_refresh_token != self.refresh_token:

--- a/tests/unittests/test_refresh_token_rotation.py
+++ b/tests/unittests/test_refresh_token_rotation.py
@@ -132,7 +132,7 @@ class TestRefreshTokenRotation(unittest.TestCase):
 
     @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
     def test_rotated_token_persisted_to_config_file(self, mock_request):
-        """_write_config atomically updates the config file with the rotated refresh token."""
+        """_write_config updates the config file with the rotated refresh token."""
         mock_request.return_value = _mock_login_response(refresh_token='rotated-token')
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unittests/test_refresh_token_rotation.py
+++ b/tests/unittests/test_refresh_token_rotation.py
@@ -1,0 +1,188 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from tap_salesforce.salesforce import Salesforce
+
+
+def _make_sf(**kwargs):
+    defaults = dict(
+        refresh_token='initial-refresh-token',
+        sf_client_id='client-id',
+        sf_client_secret='client-secret',
+        default_start_date='2021-01-01T00:00:00Z',
+        api_type='REST',
+    )
+    defaults.update(kwargs)
+    return Salesforce(**defaults)
+
+
+def _mock_login_response(access_token='new-access', instance_url='https://sf.example.com',
+                         refresh_token=None):
+    payload = {'access_token': access_token, 'instance_url': instance_url}
+    if refresh_token is not None:
+        payload['refresh_token'] = refresh_token
+    resp = mock.MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+class TestRefreshTokenRotation(unittest.TestCase):
+
+    # ------------------------------------------------------------------ #
+    # login() updates self.refresh_token when rotation token is returned  #
+    # ------------------------------------------------------------------ #
+
+    @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
+    def test_login_updates_refresh_token_when_rotated(self, mock_request):
+        """A new refresh_token in the OAuth response replaces the stored one."""
+        mock_request.return_value = _mock_login_response(refresh_token='rotated-token')
+
+        sf = _make_sf()
+        with mock.patch.object(sf, 'login_timer') as _timer:
+            sf.login_timer = mock.MagicMock()
+            # Patch threading.Timer so no real background thread starts
+            with mock.patch('threading.Timer') as mock_timer_cls:
+                mock_timer_cls.return_value = mock.MagicMock()
+                sf.login()
+
+        self.assertEqual(sf.refresh_token, 'rotated-token')
+
+    @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
+    def test_login_keeps_refresh_token_when_not_in_response(self, mock_request):
+        """refresh_token is unchanged when the OAuth response omits it."""
+        mock_request.return_value = _mock_login_response()  # no refresh_token key
+
+        sf = _make_sf()
+        with mock.patch('threading.Timer') as mock_timer_cls:
+            mock_timer_cls.return_value = mock.MagicMock()
+            sf.login()
+
+        self.assertEqual(sf.refresh_token, 'initial-refresh-token')
+
+    # ------------------------------------------------------------------ #
+    # _write_config is called only when the token changes                 #
+    # ------------------------------------------------------------------ #
+
+    @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
+    def test_write_config_called_when_token_rotated(self, mock_request):
+        """_write_config is called when a rotated refresh token is received."""
+        mock_request.return_value = _mock_login_response(refresh_token='rotated-token')
+
+        sf = _make_sf()
+        with mock.patch.object(sf, '_write_config') as mock_write_config:
+            with mock.patch('threading.Timer') as mock_timer_cls:
+                mock_timer_cls.return_value = mock.MagicMock()
+                sf.login()
+
+        mock_write_config.assert_called_once()
+
+    @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
+    def test_write_config_not_called_when_no_new_token(self, mock_request):
+        """_write_config is NOT called when no refresh_token is returned."""
+        mock_request.return_value = _mock_login_response()
+
+        sf = _make_sf()
+        with mock.patch.object(sf, '_write_config') as mock_write_config:
+            with mock.patch('threading.Timer') as mock_timer_cls:
+                mock_timer_cls.return_value = mock.MagicMock()
+                sf.login()
+
+        mock_write_config.assert_not_called()
+
+    @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
+    def test_write_config_not_called_when_same_token_returned(self, mock_request):
+        """_write_config is NOT called when the response echoes the existing token."""
+        mock_request.return_value = _mock_login_response(
+            refresh_token='initial-refresh-token'  # same as the initial value
+        )
+
+        sf = _make_sf()
+        with mock.patch.object(sf, '_write_config') as mock_write_config:
+            with mock.patch('threading.Timer') as mock_timer_cls:
+                mock_timer_cls.return_value = mock.MagicMock()
+                sf.login()
+
+        mock_write_config.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # access_token is always updated regardless of rotation               #
+    # ------------------------------------------------------------------ #
+
+    @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
+    def test_access_token_always_updated(self, mock_request):
+        """access_token is refreshed regardless of whether refresh_token rotates."""
+        mock_request.return_value = _mock_login_response(
+            access_token='brand-new-access-token',
+            refresh_token='rotated-token'
+        )
+
+        sf = _make_sf()
+        with mock.patch('threading.Timer') as mock_timer_cls:
+            mock_timer_cls.return_value = mock.MagicMock()
+            sf.login()
+
+        self.assertEqual(sf.access_token, 'brand-new-access-token')
+
+    # ------------------------------------------------------------------ #
+    # Persistence: callback writes new token to config file               #
+    # ------------------------------------------------------------------ #
+
+    @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
+    def test_rotated_token_persisted_to_config_file(self, mock_request):
+        """_write_config atomically updates the config file with the rotated refresh token."""
+        mock_request.return_value = _mock_login_response(refresh_token='rotated-token')
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, 'config.json')
+            initial_config = {
+                'refresh_token': 'initial-refresh-token',
+                'client_id': 'client-id',
+                'client_secret': 'client-secret',
+                'start_date': '2021-01-01T00:00:00Z',
+                'api_type': 'REST',
+            }
+            with open(config_path, 'w') as f:
+                json.dump(initial_config, f)
+
+            sf = _make_sf(config_path=config_path)
+            with mock.patch('threading.Timer') as mock_timer_cls:
+                mock_timer_cls.return_value = mock.MagicMock()
+                sf.login()
+
+            with open(config_path) as f:
+                saved_config = json.load(f)
+
+            self.assertEqual(saved_config['refresh_token'], 'rotated-token')
+            # Other keys must be preserved
+            self.assertEqual(saved_config['client_id'], 'client-id')
+
+    # ------------------------------------------------------------------ #
+    # Subsequent login() calls use the updated (rotated) refresh token    #
+    # ------------------------------------------------------------------ #
+
+    @mock.patch('tap_salesforce.salesforce.Salesforce._make_request')
+    def test_subsequent_login_uses_rotated_token(self, mock_request):
+        """After rotation, the second login sends the new refresh_token."""
+        first_response = _mock_login_response(refresh_token='second-token')
+        second_response = _mock_login_response(refresh_token='third-token')
+        mock_request.side_effect = [first_response, second_response]
+
+        sf = _make_sf()
+        with mock.patch('threading.Timer') as mock_timer_cls:
+            mock_timer_cls.return_value = mock.MagicMock()
+            sf.login()
+            self.assertEqual(sf.refresh_token, 'second-token')
+            sf.login()
+            self.assertEqual(sf.refresh_token, 'third-token')
+
+        # Verify the second POST used the rotated token
+        second_call_body = mock_request.call_args_list[1][1].get('body') or \
+                           mock_request.call_args_list[1][0][2]
+        self.assertIn('second-token', str(second_call_body))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unittests/test_refresh_token_rotation.py
+++ b/tests/unittests/test_refresh_token_rotation.py
@@ -41,9 +41,7 @@ class TestRefreshTokenRotation(unittest.TestCase):
         mock_request.return_value = _mock_login_response(refresh_token='rotated-token')
 
         sf = _make_sf()
-        with mock.patch.object(sf, 'login_timer') as _timer:
-            sf.login_timer = mock.MagicMock()
-            # Patch threading.Timer so no real background thread starts
+        with mock.patch.object(sf, '_write_config'):
             with mock.patch('threading.Timer') as mock_timer_cls:
                 mock_timer_cls.return_value = mock.MagicMock()
                 sf.login()
@@ -120,9 +118,10 @@ class TestRefreshTokenRotation(unittest.TestCase):
         )
 
         sf = _make_sf()
-        with mock.patch('threading.Timer') as mock_timer_cls:
-            mock_timer_cls.return_value = mock.MagicMock()
-            sf.login()
+        with mock.patch.object(sf, '_write_config'):
+            with mock.patch('threading.Timer') as mock_timer_cls:
+                mock_timer_cls.return_value = mock.MagicMock()
+                sf.login()
 
         self.assertEqual(sf.access_token, 'brand-new-access-token')
 
@@ -135,29 +134,32 @@ class TestRefreshTokenRotation(unittest.TestCase):
         """_write_config updates the config file with the rotated refresh token."""
         mock_request.return_value = _mock_login_response(refresh_token='rotated-token')
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            config_path = os.path.join(tmpdir, 'config.json')
-            initial_config = {
-                'refresh_token': 'initial-refresh-token',
-                'client_id': 'client-id',
-                'client_secret': 'client-secret',
-                'start_date': '2021-01-01T00:00:00Z',
-                'api_type': 'REST',
-            }
-            with open(config_path, 'w') as f:
-                json.dump(initial_config, f)
+        tmpdir_obj = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir_obj.cleanup)
+        tmpdir = tmpdir_obj.name
 
-            sf = _make_sf(config_path=config_path)
-            with mock.patch('threading.Timer') as mock_timer_cls:
-                mock_timer_cls.return_value = mock.MagicMock()
-                sf.login()
+        config_path = os.path.join(tmpdir, 'config.json')
+        initial_config = {
+            'refresh_token': 'initial-refresh-token',
+            'client_id': 'client-id',
+            'client_secret': 'client-secret',
+            'start_date': '2021-01-01T00:00:00Z',
+            'api_type': 'REST',
+        }
+        with open(config_path, 'w') as f:
+            json.dump(initial_config, f)
 
-            with open(config_path) as f:
-                saved_config = json.load(f)
+        sf = _make_sf(config_path=config_path)
+        with mock.patch('threading.Timer') as mock_timer_cls:
+            mock_timer_cls.return_value = mock.MagicMock()
+            sf.login()
 
-            self.assertEqual(saved_config['refresh_token'], 'rotated-token')
-            # Other keys must be preserved
-            self.assertEqual(saved_config['client_id'], 'client-id')
+        with open(config_path) as f:
+            saved_config = json.load(f)
+
+        self.assertEqual(saved_config['refresh_token'], 'rotated-token')
+        # Other keys must be preserved
+        self.assertEqual(saved_config['client_id'], 'client-id')
 
     # ------------------------------------------------------------------ #
     # Subsequent login() calls use the updated (rotated) refresh token    #
@@ -171,12 +173,13 @@ class TestRefreshTokenRotation(unittest.TestCase):
         mock_request.side_effect = [first_response, second_response]
 
         sf = _make_sf()
-        with mock.patch('threading.Timer') as mock_timer_cls:
-            mock_timer_cls.return_value = mock.MagicMock()
-            sf.login()
-            self.assertEqual(sf.refresh_token, 'second-token')
-            sf.login()
-            self.assertEqual(sf.refresh_token, 'third-token')
+        with mock.patch.object(sf, '_write_config'):
+            with mock.patch('threading.Timer') as mock_timer_cls:
+                mock_timer_cls.return_value = mock.MagicMock()
+                sf.login()
+                self.assertEqual(sf.refresh_token, 'second-token')
+                sf.login()
+                self.assertEqual(sf.refresh_token, 'third-token')
 
         # Verify the second POST used the rotated token
         second_call_body = mock_request.call_args_list[1][1].get('body') or \


### PR DESCRIPTION
## Summary

Salesforce is enforcing refresh token rotation for OAuth integrations starting May 11, 2026. When rotation is enabled, each refresh token can only be used once — a new refresh token is returned with every token exchange, and the previous one is immediately invalidated.

This PR adds support for refresh token rotation in the tap-salesforce connector.

## Changes

### `tap_salesforce/salesforce/__init__.py`
- Added `config_path` parameter to `Salesforce.__init__()` replacing the previous `token_refresh_callback` approach
- Added `_write_config()` instance method that reads the config file, updates only the `refresh_token` key, and writes it back — consistent with the pattern used in tap-shopify
- Updated `login()` to detect rotation (new token present and different from current), update `self.refresh_token` in memory, and call `_write_config()` to persist to disk

### `tap_salesforce/__init__.py`
- Passes `config_path=args.config_path` to `Salesforce()` — `singer_utils.parse_args()` already exposes `args.config_path` from the `-c` flag, so no additional argument parsing is needed

## Behavior

| Scenario | Behavior |
|---|---|
| Salesforce returns a new `refresh_token` | Token updated in memory + persisted to config file |
| Salesforce does not return a `refresh_token` | No change, no file write |
| Salesforce echoes the same `refresh_token` | No change, no file write |
| `config_path` not provided | Token updated in memory only, file write skipped |

## Testing

Unit tests added in `tests/unittests/test_refresh_token_rotation.py` covering:
- `login()` updates `self.refresh_token` when rotation token is returned
- `login()` keeps existing token when none returned
- `_write_config()` called only when token changes
- `_write_config()` not called when token unchanged or absent
- `access_token` always updated regardless of rotation
- Rotated token persisted correctly to config file
- Subsequent `login()` calls use the updated token

## References
- Salesforce refresh token rotation enforcement: May 11, 2026